### PR TITLE
Eliminate PHP4-style constructors

### DIFF
--- a/inc/tags.php
+++ b/inc/tags.php
@@ -19,7 +19,7 @@ class o2_Tags extends o2_Terms_In_Comments {
 		add_filter( 'comment_text',           array( 'o2_Tags', 'tag_links' ), 15 );
 		add_filter( 'o2_post_fragment',       array( $this, 'append_old_tags_to_fragment' ), 10, 1 );
 
-		parent::o2_Terms_In_Comments( 'post_tag' );
+		parent::__construct( 'post_tag' );
 	}
 
 	/**

--- a/inc/terms-in-comments.php
+++ b/inc/terms-in-comments.php
@@ -7,7 +7,7 @@ class o2_Terms_In_Comments {
 	var $taxonomy;
 	var $meta_key;
 
-	function o2_Terms_In_Comments( $taxonomy, $meta_key = false ) {
+	function __construct( $taxonomy, $meta_key = false ) {
 		$this->taxonomy = $taxonomy;
 		$this->meta_key = empty( $meta_key ) ? "_{$taxonomy}_term_meta" : $meta_key;
 

--- a/inc/xposts.php
+++ b/inc/xposts.php
@@ -37,7 +37,7 @@ class o2_Xposts extends o2_Terms_In_Comments {
 		// Don't let xposts participate in resolved/unresolved
 		add_filter( 'o2_resolved_posts_maybe_mark_new_as_unresolved', array( $this, 'o2rpx_dont_mark_xposts' ), 10, 2 );
 
-		parent::o2_Terms_In_Comments( 'xposts' );
+		parent::__construct( 'xposts' );
 	}
 
 	/**


### PR DESCRIPTION
See https://make.wordpress.org/core/2015/07/02/deprecating-php4-style-constructors-in-wordpress-4-3/