### PR TITLE
Fix notices during preview

### DIFF
--- a/inc/read-api.php
+++ b/inc/read-api.php
@@ -474,6 +474,9 @@ class o2_Read_API extends o2_API_Base {
 					$content = "<h1>{$message->titleRaw}</h1>";
 				}
 
+				add_filter( 'o2_should_process_terms', '__return_false' );
+				add_filter( 'o2_process_the_content', '__return_false' );
+
 				$content .= trim( apply_filters( 'the_content', $message->contentRaw ) );
 
 				break;

--- a/modules/post-actions/load.php
+++ b/modules/post-actions/load.php
@@ -75,6 +75,11 @@ class o2_Post_Actions {
 
 	function before_post_likes( $content ) {
 		global $post;
+
+		if ( ! apply_filters( 'o2_process_the_content', '__return_true' ) ) {
+			return $content;
+		}
+
 		$actions = apply_filters( 'o2_filter_post_actions', array(), $post->ID );
 
 		$content .= "<nav class='o2-post-footer-actions'>";
@@ -93,6 +98,11 @@ class o2_Post_Actions {
 
 	function after_post_likes( $content ) {
 		global $post;
+
+		if ( ! apply_filters( 'o2_process_the_content', '__return_true' ) ) {
+			return $content;
+		}
+
 		$actions = apply_filters( 'o2_filter_post_actions', array(), $post->ID );
 
 		$content .= "</div>";

--- a/modules/to-do/load.php
+++ b/modules/to-do/load.php
@@ -87,7 +87,10 @@ class o2_ToDos extends o2_API_Base {
 	 */
 	public static function get_first_state_slug() {
 		global $o2_post_action_states;
-		return array_shift( array_keys( $o2_post_action_states[ self::post_actions_key ] ) );
+
+		$keys = array_keys( $o2_post_action_states[ self::post_actions_key ] );
+
+		return array_shift( $keys );
 	}
 
 	/**
@@ -97,7 +100,10 @@ class o2_ToDos extends o2_API_Base {
 	 */
 	public static function get_last_state_slug() {
 		global $o2_post_action_states;
-		return array_pop( array_keys( $o2_post_action_states[ self::post_actions_key ] ) );
+
+		$keys = array_keys( $o2_post_action_states[ self::post_actions_key ] );
+
+		return array_pop( $keys );
 	}
 
 	/**


### PR DESCRIPTION
Fixes #4 

I was looking into this. The problem is [`the_content` filter added on `$content`](https://github.com/Automattic/o2/blob/cc022db37da7d1274cfc499a7f2ba0cff5a8c9ea/inc/read-api.php#L477) to return the preview text.

[Some](https://github.com/Automattic/o2/blob/cc022db37da7d1274cfc499a7f2ba0cff5a8c9ea/inc/xposts.php#L133) [of](https://github.com/Automattic/o2/blob/cc022db37da7d1274cfc499a7f2ba0cff5a8c9ea/modules/post-actions/load.php#L77) [the](https://github.com/Automattic/o2/blob/cc022db37da7d1274cfc499a7f2ba0cff5a8c9ea/modules/post-actions/load.php#L95) functions that throws an error is because they expect a `$post` object that doesn't exist.

With `add_filter( 'o2_should_process_terms', '__return_false' );` one of the notices disappear (the one of xposts.php).

I tried to remove the filters in [modules/post-actions/load.php](https://github.com/Automattic/o2/blob/cc022db37da7d1274cfc499a7f2ba0cff5a8c9ea/modules/post-actions/load.php#L29-L30) but `remove_filter('the_content', array('o2_Post_Actions', 'before_post_likes', 28)` doesn't work because the filter id generated by `_wp_filter_build_unique_id` in [core](https://github.com/WordPress/WordPress/blob/de881c4a97b400f6353c055c7e502e2be4f4ddce/wp-includes/plugin.php#L911-L947) is not the same as when the [filter is added](https://github.com/Automattic/o2/blob/cc022db37da7d1274cfc499a7f2ba0cff5a8c9ea/modules/post-actions/load.php#L29).

My solution (open to new ideas) was to create a new filter and call it on the preview method and "disable" those two filters. Seems to work.

Also I added a variable association to eliminate those "Only variables should be passed by reference" notices.