### PR TITLE
Fix anonymous author check by supplying missing currentUser property

### DIFF
--- a/js/views/comment.js
+++ b/js/views/comment.js
@@ -375,7 +375,7 @@ o2.Views.Comment = ( function( $, Backbone ) {
 			$.extend( true, jsonifiedModel, this.options );
 
 			jsonifiedModel.isNew = this.model.isNew();
-			jsonifiedModel.isAnonymousAuthor = ( 0 === jsonifiedModel.userLogin.length ) && ( 0 === jsonifiedModel.noprivUserName.length );
+			jsonifiedModel.isAnonymousAuthor = ( 0 === jsonifiedModel.currentUser.userLogin.length ) && ( 0 === jsonifiedModel.noprivUserName.length );
 			jsonifiedModel.strings = o2.strings;
 			jsonifiedModel.commentFormExtras = o2.commentFormExtras;
 			jsonifiedModel.someoneElsesComment = someoneElsesComment;


### PR DESCRIPTION
We were noticing that a page with comments was failing to render. There was also JS error on the page, which I thought might be the cause, and it was.

The error was:

> Cannot read property 'length' of null

And it was happening on this line in [`views/comment.js`](https://github.com/Automattic/o2/blob/cc022db37da7d1274cfc499a7f2ba0cff5a8c9ea/js/views/comment.js#L378):

```js
jsonifiedModel.isAnonymousAuthor = ( 0 === jsonifiedModel.userLogin.length ) && ( 0 === jsonifiedModel.noprivUserName.length );
```

It should be referring to `jsonifiedModel.currentUser.userLogin` instead of `jsonifiedModel.userLogin`.



