### PR TITLE
Fix-live-widget-#26

### DIFF
--- a/js/app/main.js
+++ b/js/app/main.js
@@ -75,6 +75,7 @@ o2.Routers.App = ( function( $, Backbone ) {
 				isPage: 'page' == o2.options.viewType ? true : false,
 				is404: '404' == o2.options.viewType ? true : false,
 				isSearch: 'search' == o2.options.viewType ? true : false,
+				isPreview: true == o2.options.isPreview ? true : false,
 				havePosts: o2.options.havePosts
 			} );
 

--- a/modules/live-comments/js/collections/items.js
+++ b/modules/live-comments/js/collections/items.js
@@ -23,8 +23,10 @@ o2.Collections.LiveCommentsItems = ( function( $, Backbone ) {
 			if ( 'undefined' != typeof foundItem ) {
 				foundItem.set( itemHash );
 			} else {
-				this.add( new o2.Models.LiveCommentsItem( itemHash ) );
-			}
+				if ( ! o2.options.isPreview ) {
+					this.add( new o2.Models.LiveCommentsItem( itemHash ) );
+				}
+			}	
 		}
 	} );
 } )( jQuery, Backbone );

--- a/o2.php
+++ b/o2.php
@@ -361,6 +361,7 @@ class o2 {
 				'userMustBeLoggedInToComment'          => ( "1" === get_option( 'comment_registration' ) ),
 				'requireUserNameAndEmailIfNotLoggedIn' => ( "1" === get_option( 'require_name_email' ) ),
 				'viewType'                             => $view_type,
+				'isPreview'                            => is_preview(),
 				'showExtended'                         => strip_tags( wp_kses_no_null( trim( __( 'Show full post', 'o2' ) ) ) ),
 				'hideExtended'                         => strip_tags( wp_kses_no_null( trim( __( 'Hide extended post', 'o2' ) ) ) ),
 				'searchQuery'                          => get_search_query(),


### PR DESCRIPTION
This makes it so the post is only added to the live-comments widget if
the current view is not a preview solving #26.  Adds isPreview to
o2.options and to pageMeta.  There is a conditional check when adding an
item to the live-comments widget to prevent the post being added in a
preview state, while still a draft.  Let me know what tidying up the code needs, feedback is very appreciated!