### PR TITLE
Adds local avatar support

### DIFF
--- a/js/collections/users.js
+++ b/js/collections/users.js
@@ -65,10 +65,15 @@ o2.Collections.Users = ( function( $, Backbone ) {
 
 			var userAttributes = _.clone( user.attributes );
 
-			// Add the avatar info
-			var defaultAvatar = ( 'undefined' !== typeof o2.options.defaultAvatar ) ? o2.options.defaultAvatar : 'identicon';
-			userAttributes.avatar = "https://gravatar.com/avatar/" + userAttributes.hash + '?d=' + defaultAvatar;
-			userAttributes.avatarSize = avatarSize;
+			// Add the avatar info. If there is a local avatar in use, override user gravatar.
+			if ( false !== userAttributes.localAvatar ) {
+				userAttributes.avatar = userAttributes.localAvatar;
+				userAttributes.avatarSize = avatarSize;
+			} else {
+				var defaultAvatar = ( 'undefined' !== typeof o2.options.defaultAvatar ) ? o2.options.defaultAvatar : 'identicon';
+				userAttributes.avatar = "https://gravatar.com/avatar/" + userAttributes.hash + '?d=' + defaultAvatar;
+				userAttributes.avatarSize = avatarSize;
+			}
 
 			return userAttributes;
 		},
@@ -138,4 +143,3 @@ o2.Collections.Users = ( function( $, Backbone ) {
 
 	} );
 } )( jQuery, Backbone );
-


### PR DESCRIPTION
This was tested using https://wordpress.org/plugins/wp-user-avatar/,
which has 200,000 active installs.  This will handle local avatars that
are using get_avatar() for functionality.  Solves #14, for most cases.
There are likely edge cases where this may not work, but for the most
part, I imagine this will add support for local avatars.