### PR TITLE
This PR fixes the net::ERR_CONNECTION_CLOSED issue seen in browsers that support HTTP2.

### DIFF
--- a/js/utils/polling.js
+++ b/js/utils/polling.js
@@ -25,6 +25,7 @@ o2.Polling = ( function( $, Backbone ) {
 
 			o2.options.currentRequest = Date.now();
 			$.ajax( {
+                method: 'POST',
 				dataType:  'json',
 				url:       o2.options.readURL + '&method=poll',
 				xhrFields: {

--- a/js/utils/polling.js
+++ b/js/utils/polling.js
@@ -25,7 +25,7 @@ o2.Polling = ( function( $, Backbone ) {
 
 			o2.options.currentRequest = Date.now();
 			$.ajax( {
-                method: 'POST',
+				method: 'POST',
 				dataType:  'json',
 				url:       o2.options.readURL + '&method=poll',
 				xhrFields: {


### PR DESCRIPTION
Really long query strings break HTTP2 requests to nginx. I suspect there's an issue with the way a really long HTTP2 :path pseudo-header is handled in nginx, but I didn't root cause it that far.

The least impactful and simplest way to work around HTTP2 bug in nginx was to change the poll method to use POST instead of GET.