### PR TITLE
O2 request size reduction

### DIFF
--- a/inc/read-api.php
+++ b/inc/read-api.php
@@ -104,7 +104,11 @@ class o2_Read_API extends o2_API_Base {
 			if ( isset( $_REQUEST['scripts'] ) ) {
 
 				// Parse and sanitize the script handles already output
-				$initial_scripts = isset( $_REQUEST['scripts'] ) && is_array( $_REQUEST['scripts'] ) ? array_map( 'sanitize_text_field', $_REQUEST['scripts'] ) : false;
+				if ( ! is_array( $_REQUEST['scripts'] ) ) {
+					$_REQUEST['scripts'] = explode( ',', $_REQUEST['scripts'] );
+				}
+				
+				$initial_scripts = is_array( $_REQUEST['scripts'] ) ? array_map( 'sanitize_text_field', $_REQUEST['scripts'] ) : null;
 
 				if ( is_array( $initial_scripts ) ) {
 					global $wp_scripts;
@@ -167,8 +171,13 @@ class o2_Read_API extends o2_API_Base {
 			// Attach styles
 			if ( isset( $_REQUEST['styles'] ) ) {
 
+				// Parse and sanitize the script handles already output
+				if ( ! is_array( $_REQUEST['styles'] ) ) {
+					$_REQUEST['styles'] = explode( ',', $_REQUEST['styles'] );
+				}
+	
 				// Parse and sanitize the style handles already output
-				$initial_styles = isset( $_REQUEST['styles'] ) && is_array( $_REQUEST['styles'] ) ? array_map( 'sanitize_text_field', $_REQUEST['styles'] ) : false;
+				$initial_styles = is_array( $_REQUEST['styles'] ) ? array_map( 'sanitize_text_field', $_REQUEST['styles'] ) : null;
 
 				if ( is_array( $initial_styles ) ) {
 					global $wp_styles;

--- a/js/utils/polling.js
+++ b/js/utils/polling.js
@@ -16,8 +16,8 @@ o2.Polling = ( function( $, Backbone ) {
 				queryVars: o2.options.queryVars,
 				since: o2.options.loadTime,
 				rando: Math.random(),
-				scripts: o2.options.scripts,
-				styles: o2.options.styles,
+				scripts: o2.options.scripts.join(),
+				styles: o2.options.styles.join(),
 				postId: o2.options.postId
 			};
 


### PR DESCRIPTION
The current code produces a form-urlencoded string which contains an array of scripts[] and an array of styles[]. The form-urlencoded syntax necessitates that the array notation text be repeated for each item in the array, like so:
`scripts[]=jquery&scripts[]=jquery-core&scripts[]=jquery-migrate ... 
&
styles[]=bugout-css&styles[]=smileyproject&styles[]=follow_css ...
&`
This means that the use of the query string array notation translates to 10 bytes (scripts[]=) for each script and 7 bytes (styles[]=) for each style + the length of the actual value.

I was able to get a ~30%+ reduction in the size of the request by simply changing the structure of the data to a single variable for scripts and a single variable for styles, each of which hold a comma-delimited list of values, thus eliminating the need for the verbose array syntax.

The changes here are backwards compatible in the sense that they can be deployed to the server, and the front-end code should continue to work even without refreshing the browser. Of course, the client won't get the benefit until the browser is refreshed and the new client-code is loaded.