### PR TITLE
Escape username to fix CSS selector syntax bug

### DIFF
--- a/js/collections/users.js
+++ b/js/collections/users.js
@@ -37,7 +37,7 @@ o2.Collections.Users = ( function( $, Backbone ) {
 					user = new o2.Models.User( {
 						userLogin   : object.userLogin,
 						displayName : object.userLogin,
-						modelClass  : 'o2-incomplete-' + object.userLogin
+						modelClass  : 'o2-incomplete-' + CSS.escape(object.userLogin)
 					} );
 
 					// add it to the collection
@@ -116,7 +116,7 @@ o2.Collections.Users = ( function( $, Backbone ) {
 			var user = this.getUserFor( { userLogin: userLogin } );
 
 			// update img src's and a href's with .o2-incomplete-{userLogin}
-			var selectorClass = 'o2-incomplete-' + userLogin;
+			var selectorClass = 'o2-incomplete-' + CSS.escape(userLogin);
 
 			$( 'a.' + selectorClass ).each( function() {
 				$( this ).attr( 'href', user.url ).removeClass( selectorClass );
@@ -138,4 +138,3 @@ o2.Collections.Users = ( function( $, Backbone ) {
 
 	} );
 } )( jQuery, Backbone );
-

--- a/js/utils/cssescape.js
+++ b/js/utils/cssescape.js
@@ -1,0 +1,103 @@
+/*! https://mths.be/cssescape v1.5.0 by @mathias | MIT license */
+;(function(root, factory) {
+	// https://github.com/umdjs/umd/blob/master/returnExports.js
+	if (typeof exports == 'object') {
+		// For Node.js.
+		module.exports = factory(root);
+	} else if (typeof define == 'function' && define.amd) {
+		// For AMD. Register as an anonymous module.
+		define([], factory.bind(root, root));
+	} else {
+		// For browser globals (not exposing the function separately).
+		factory(root);
+	}
+}(typeof global != 'undefined' ? global : this, function(root) {
+
+	if (root.CSS && root.CSS.escape) {
+		return root.CSS.escape;
+	}
+
+	// https://drafts.csswg.org/cssom/#serialize-an-identifier
+	var cssEscape = function(value) {
+		var string = String(value);
+		var length = string.length;
+		var index = -1;
+		var codeUnit;
+		var result = '';
+		var firstCodeUnit = string.charCodeAt(0);
+		while (++index < length) {
+			codeUnit = string.charCodeAt(index);
+			// Note: there’s no need to special-case astral symbols, surrogate
+			// pairs, or lone surrogates.
+
+			// If the character is NULL (U+0000), then the REPLACEMENT CHARACTER
+			// (U+FFFD).
+			if (codeUnit == 0x0000) {
+				result += '\uFFFD';
+				continue;
+			}
+
+			if (
+				// If the character is in the range [\1-\1F] (U+0001 to U+001F) or is
+				// U+007F, […]
+				(codeUnit >= 0x0001 && codeUnit <= 0x001F) || codeUnit == 0x007F ||
+				// If the character is the first character and is in the range [0-9]
+				// (U+0030 to U+0039), […]
+				(index == 0 && codeUnit >= 0x0030 && codeUnit <= 0x0039) ||
+				// If the character is the second character and is in the range [0-9]
+				// (U+0030 to U+0039) and the first character is a `-` (U+002D), […]
+				(
+					index == 1 &&
+					codeUnit >= 0x0030 && codeUnit <= 0x0039 &&
+					firstCodeUnit == 0x002D
+				)
+			) {
+				// https://drafts.csswg.org/cssom/#escape-a-character-as-code-point
+				result += '\\' + codeUnit.toString(16) + ' ';
+				continue;
+			}
+
+			if (
+				// If the character is the first character and is a `-` (U+002D), and
+				// there is no second character, […]
+				index == 0 &&
+				length == 1 &&
+				codeUnit == 0x002D
+			) {
+				result += '\\' + string.charAt(index);
+				continue;
+			}
+
+			// If the character is not handled by one of the above rules and is
+			// greater than or equal to U+0080, is `-` (U+002D) or `_` (U+005F), or
+			// is in one of the ranges [0-9] (U+0030 to U+0039), [A-Z] (U+0041 to
+			// U+005A), or [a-z] (U+0061 to U+007A), […]
+			if (
+				codeUnit >= 0x0080 ||
+				codeUnit == 0x002D ||
+				codeUnit == 0x005F ||
+				codeUnit >= 0x0030 && codeUnit <= 0x0039 ||
+				codeUnit >= 0x0041 && codeUnit <= 0x005A ||
+				codeUnit >= 0x0061 && codeUnit <= 0x007A
+			) {
+				// the character itself
+				result += string.charAt(index);
+				continue;
+			}
+
+			// Otherwise, the escaped character.
+			// https://drafts.csswg.org/cssom/#escape-a-character
+			result += '\\' + string.charAt(index);
+
+		}
+		return result;
+	};
+
+	if (!root.CSS) {
+		root.CSS = {};
+	}
+
+	root.CSS.escape = cssEscape;
+	return cssEscape;
+
+}));

--- a/o2.php
+++ b/o2.php
@@ -171,6 +171,7 @@ class o2 {
 
 		// Utils
 		wp_enqueue_script( 'o2-compare-times',        plugins_url( 'o2/js/utils/compare-times.js' ), array( 'jquery' ) );
+		wp_enqueue_script( 'o2-cssescape',            plugins_url( 'o2/js/utils/cssescape.js' ), array( 'backbone', 'jquery' ) );
 		wp_enqueue_script( 'o2-events',               plugins_url( 'o2/js/utils/events.js' ), array( 'backbone', 'jquery' ) );
 		wp_enqueue_script( 'o2-highlight-on-inview',  plugins_url( 'o2/js/utils/highlight-on-inview.js' ), array( 'jquery' ) );
 		wp_enqueue_script( 'o2-highlight',            plugins_url( 'o2/js/utils/jquery.highlight.js' ), array( 'jquery' ) );
@@ -239,6 +240,7 @@ class o2 {
 				'o2-collections-posts',
 				'o2-collections-users',
 				'o2-compare-times',
+				'o2-cssescape',
 				'o2-events',
 				'o2-highlight',
 				'o2-highlight-on-inview',


### PR DESCRIPTION
Fixes https://github.com/Automattic/o2/issues/16
    * Added CSS.escape() polyfill.
    * Used CSS.escape() polyfill to escape css selectors being built from the username.