### PR TITLE
Changed modelClass to use hash instead of userLogin.

### DIFF
--- a/js/collections/users.js
+++ b/js/collections/users.js
@@ -37,7 +37,7 @@ o2.Collections.Users = ( function( $, Backbone ) {
 					user = new o2.Models.User( {
 						userLogin   : object.userLogin,
 						displayName : object.userLogin,
-						modelClass  : 'o2-incomplete-' + object.userLogin
+						modelClass  : 'o2-incomplete-' + object.hash
 					} );
 
 					// add it to the collection
@@ -115,8 +115,7 @@ o2.Collections.Users = ( function( $, Backbone ) {
 
 			var user = this.getUserFor( { userLogin: userLogin } );
 
-			// update img src's and a href's with .o2-incomplete-{userLogin}
-			var selectorClass = 'o2-incomplete-' + userLogin;
+			var selectorClass = 'o2-incomplete-' + user.hash; 
 
 			$( 'a.' + selectorClass ).each( function() {
 				$( this ).attr( 'href', user.url ).removeClass( selectorClass );
@@ -138,4 +137,3 @@ o2.Collections.Users = ( function( $, Backbone ) {
 
 	} );
 } )( jQuery, Backbone );
-


### PR DESCRIPTION
The userLogin field can contain illegal characters for css and so doesn't make a good choice to use as part of the modelClass css selector.

A hash is already part of the user object, so I updated the css selector to use it instead of userLogin.