### PR TITLE
Empty xposts array warning

### DIFF
--- a/inc/xposts.php
+++ b/inc/xposts.php
@@ -225,7 +225,7 @@ class o2_Xposts extends o2_Terms_In_Comments {
 		}
 
 		$this->site_suggestions();
-		return array_intersect( $xposts, $this->subdomains[ get_current_blog_id() ] );
+		return array_intersect( $xposts, (array) $this->subdomains[ get_current_blog_id() ] );
 	}
 
 	/**


### PR DESCRIPTION
When there are no sites to xpost to (such as a single site install), there are PHP warnings thrown when using content such as `+1` in a post or comment. If the site returns PHP warnings, the user will get the black o2 error popup box. Make sure to use array_intersect on an array in `filter_xposts`. The warnings are:

`PHP Warning:  array_intersect(): Argument #2 is not an array in /wp-content/plugins/o2/inc/xposts.php on line 228`
`PHP Warning:  Invalid argument supplied for foreach() in /wp-content/plugins/o2/inc/terms-in-comments.php on line 36`
`PHP Warning:  array_intersect(): Argument #2 is not an array in /wp-content/plugins/o2/inc/xposts.php on line 228`