### PR TITLE
Fix logic for 'Log in to Reply' button

### DIFF
--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -132,19 +132,19 @@ if ( !function_exists( 'o2_get_default_post_actions' ) ) {
 
 		// Reply
 		if ( comments_open( $post_ID ) && ! post_password_required( $post_ID ) ) {
-			if ( get_option( 'comment_registration' ) && is_user_logged_in() ) {
+			if ( get_option( 'comment_registration' ) && ! is_user_logged_in() ) {
 				$actions[20] = array(
-					'action' => 'reply',
-					'href' => get_permalink( $post_ID ) . '#respond',
-					'classes' => array( 'o2-post-reply', 'o2-reply' ),
+					'action' => 'login-to-reply',
+					'href' => wp_login_url( get_permalink( $post_ID ) . '#respond' ),
+					'classes' => array(),
 					'rel' => false,
 					'initialState' => 'default'
 				);
 			} else {
 				$actions[20] = array(
-					'action' => 'login-to-reply',
-					'href' => wp_login_url( get_permalink( $post_ID ) . '#respond' ),
-					'classes' => array(),
+					'action' => 'reply',
+					'href' => get_permalink( $post_ID ) . '#respond',
+					'classes' => array( 'o2-post-reply', 'o2-reply' ),
 					'rel' => false,
 					'initialState' => 'default'
 				);

--- a/modules/post-actions/load.php
+++ b/modules/post-actions/load.php
@@ -154,10 +154,10 @@ class o2_Post_Actions {
 			}
 
 			if ( $ok_to_reply ) {
-				if ( get_option( 'comment_registration' ) && is_user_logged_in() ) {
-					$actions[] = "<a class='o2-comment-reply genericon genericon-reply' href='#' >" . esc_html__( 'Reply', 'o2' ) . "</a>";
-				} else {
+				if ( get_option( 'comment_registration' ) && ! is_user_logged_in() ) {
 					$actions[] = "<a class='genericon genericon-reply' href='" . wp_login_url( get_comment_link( $comment ) ) . "' >" . esc_html__( 'Login to Reply', 'o2' ) . "</a>";
+				} else {
+					$actions[] = "<a class='o2-comment-reply genericon genericon-reply' href='#' >" . esc_html__( 'Reply', 'o2' ) . "</a>";
 				}
 			}
 


### PR DESCRIPTION
Fixes #52.

The button should only be displayed if comment registration is enabled and the user is not logged in.

Broken in d71599cc7083d753d34b70ed9db9a454667f9662.