### PR TITLE
Don't use the `userLogin` of the current logged in user when checking for anonymous comment authors.

### DIFF
--- a/inc/tpl/comment-edit.php
+++ b/inc/tpl/comment-edit.php
@@ -3,7 +3,7 @@
 	<img src="{{ data.author.avatar }}" width="{{ data.avatarSize }}" height="{{ data.avatarSize }}" class="avatar {{ data.author.modelClass }}" />
 	<# } #>
 	<div class="comment-meta commentmetadata">
-		<# if ( ! data.author.userLogin ) { #>
+		<# if ( data.isAnonymousAuthor ) { #>
 			<span class="comment-author">{{ data.strings.anonymous }}</span>
 		<# } else { #>
 			<a href="{{ data.author.url }}" rel="external nofollow" class="comment-author url">

--- a/inc/tpl/comment.php
+++ b/inc/tpl/comment.php
@@ -11,7 +11,7 @@
 	<img src="{{ data.author.avatar }}" width="{{ data.avatarSize }}" height="{{ data.avatarSize }}" class="avatar {{ data.author.modelClass }}" />
 	<# } #>
 	<div class="comment-meta commentmetadata o2-comment-metadata" data-o2-comment-id="{{ data.id }}">
-		<# if ( ! data.author.userLogin ) { #>
+		<# if ( data.isAnonymousAuthor ) { #>
 			<span class="comment-author">{{ data.strings.anonymous }}</span>
 		<# } else { #>
 			<a href="{{ data.author.url }}" rel="external nofollow" class="comment-author url {{ data.author.modelClass }}">

--- a/js/views/comment.js
+++ b/js/views/comment.js
@@ -375,7 +375,7 @@ o2.Views.Comment = ( function( $ ) {
 			$.extend( true, jsonifiedModel, this.options );
 
 			jsonifiedModel.isNew = this.model.isNew();
-			jsonifiedModel.isAnonymousAuthor = ( 0 === jsonifiedModel.currentUser.userLogin.length ) && ( 0 === jsonifiedModel.noprivUserName.length );
+			jsonifiedModel.isAnonymousAuthor = ( 0 === jsonifiedModel.userLogin.length ) && ( 0 === jsonifiedModel.noprivUserName.length );
 			jsonifiedModel.strings = o2.strings;
 			jsonifiedModel.commentFormExtras = o2.commentFormExtras;
 			jsonifiedModel.someoneElsesComment = someoneElsesComment;


### PR DESCRIPTION
Fixes #71.