### PR TITLE
Remove second Polldaddy oembed provider

### DIFF
--- a/o2.php
+++ b/o2.php
@@ -884,6 +884,7 @@ class o2 {
 	*/
 	public function remove_oembed_handlers() {
 		wp_oembed_remove_provider( '#https?://(.+\.)?polldaddy\.com/.*#i' );
+		wp_oembed_remove_provider( '#https?://poll\.fm/.*#i' );
 	}
 
 	/**
@@ -891,7 +892,7 @@ class o2 {
 	* may have saved
 	*/
 	public function remove_cached_incompatible_oembed( $html, $url, $args ) {
-		if ( false !== strpos( $html, 'polldaddy.com' ) ) {
+		if ( false !== strpos( $html, 'polldaddy.com' ) || false !== strpos( $html, 'poll.fm' ) ) {
 			return $url;
 		}
 		return $html;


### PR DESCRIPTION
Polldaddy also has an oembed provider and embeds under poll.fm urls. (https://core.trac.wordpress.org/browser/tags/4.6.1/src/wp-includes/class-oembed.php#L76)
This removes those, too.