### PR TITLE
Fix apply_filters bug in should_process_terms

### DIFF
--- a/inc/terms-in-comments.php
+++ b/inc/terms-in-comments.php
@@ -20,7 +20,7 @@ class o2_Terms_In_Comments {
 	 * @return boolean true if we should process TiC on this site
 	 */
 	function should_process_terms() {
-		return apply_filters( 'o2_should_process_terms', '__return_true' );
+		return apply_filters( 'o2_should_process_terms', true );
 	}
 
 	function update_comment( $comment_id ) {


### PR DESCRIPTION
apply_filters should take a value as the second argument, not a function handle. Current implementation just returns the literal string  "__return_true".