### PR TITLE
Time Shortcode: Fix JS Date Parsing During Short Months

### DIFF
--- a/modules/time-shortcode/load.php
+++ b/modules/time-shortcode/load.php
@@ -72,14 +72,7 @@ function o2_time_converter_script() {
 
 		var o2_parse_date = function ( text ) {
 			var m = /^([0-9]{4})-([0-9]{2})-([0-9]{2})T([0-9]{2}):([0-9]{2}):([0-9]{2})\+00:00$/.exec( text );
-			var d = new Date();
-			d.setUTCFullYear( +m[1] );
-			d.setUTCDate( +m[3] );
-			d.setUTCMonth( +m[2] - 1 );
-			d.setUTCHours( +m[4] );
-			d.setUTCMinutes( +m[5] );
-			d.setUTCSeconds( +m[6] );
-			return d;
+			return new Date( Date.UTC( +m[1], +m[2] - 1, +m[3], +m[4], +m[5], +m[6] ) );
 		}
 		var o2_format_date = function ( d ) {
 			var p = function( n ) {


### PR DESCRIPTION
To parse a date string, o2 creates a new Date object (initialized to the current time) then sets that Date object's year, day, month, hour, minute, and second (in that order) according to the value of the string.

If the desired date's day of the month is larger than the current month's last day, the logic breaks.

```js
d = new Date( '2016-09-30T12:00:00' );
// This new Date object (initialized not to the current time as in
// the bug but to a convenient time that demonstrates the bug)
// We now want to set `d` to October 31st, 2016

// Set the year...
d.setUTCFullYear( 2016 )
// no change

// Set the day...
d.setUTCDate( 31 );
// The month is still September, so we're trying to set the date to
// September 31st, which doesn't exist. JS will overflow and set the date
// to October 1st

// Set the month...
d.setUTCDate( 9 ); // 9 for October because JS
// This has no effect, since the date is already set to October

// Set the hour, minute, second (not shown)...

// What do we end up with?
console.log( d )
// > Sat Oct 01 2016 05:00:00 GMT-0700 (PDT)
// (exact output is timezone dependent)
```

If we were to set the month and then the day, it should work. This PR, though uses `Date.UTC()` to set everything all at once to completely avoid the consequences of this "non-atomic" way of setting the date.