### PR TITLE
Time shortcode refactor and QUnit set up

### DIFF
--- a/modules/time-shortcode/js/time-shortcode.js
+++ b/modules/time-shortcode/js/time-shortcode.js
@@ -1,8 +1,3 @@
-var o2_parse_date = function ( text ) {
-	var m = /^([0-9]{4})-([0-9]{2})-([0-9]{2})T([0-9]{2}):([0-9]{2}):([0-9]{2})\+00:00$/.exec( text );
-	return new Date( Date.UTC( +m[1], +m[2] - 1, +m[3], +m[4], +m[5], +m[6] ) );
-}
-
 var o2_format_date = function ( date ) {
 
 	var time_settings = o2_get_time_settings();

--- a/modules/time-shortcode/js/time-shortcode.js
+++ b/modules/time-shortcode/js/time-shortcode.js
@@ -17,10 +17,10 @@ var o2_format_date = function ( date ) {
 		timezone_offset = "+" + timezone_offset;
 	}
 
-	return  time_settings['days'][ date.getDay() ] + ", " 
-		+ time_settings['months'][ date.getMonth() ] + " " 
-		+ zero_prefix( date.getDate() ) + ", " 
-		+ date.getFullYear() + " " 
-		+ zero_prefix( date.getHours() ) + ":" + zero_prefix( date.getMinutes() ) 
+	return  time_settings['days'][ date.getDay() ] + ", "
+		+ time_settings['months'][ date.getMonth() ] + " "
+		+ zero_prefix( date.getDate() ) + ", "
+		+ date.getFullYear() + " "
+		+ zero_prefix( date.getHours() ) + ":" + zero_prefix( date.getMinutes() )
 		+ " UTC" + timezone_offset;
 }

--- a/modules/time-shortcode/js/time-shortcode.js
+++ b/modules/time-shortcode/js/time-shortcode.js
@@ -1,0 +1,20 @@
+var o2_parse_date = function ( text ) {
+	var m = /^([0-9]{4})-([0-9]{2})-([0-9]{2})T([0-9]{2}):([0-9]{2}):([0-9]{2})\+00:00$/.exec( text );
+	return new Date( Date.UTC( +m[1], +m[2] - 1, +m[3], +m[4], +m[5], +m[6] ) );
+}
+
+var o2_format_date = function ( d ) {
+
+	var ts = o2_get_time_settings();
+
+	var p = function( n ) {
+		return ( '00' + n ).slice( -2 );
+	};
+
+	var tz = -d.getTimezoneOffset() / 60;
+	if ( tz >= 0 ) {
+		tz = "+" + tz;
+	}
+
+	return "" + ts['days'][ d.getDay() ] + ", " + ts['months'][ d.getMonth() ] + " " + p( d.getDate() ) + ", " + d.getFullYear() + " " + p( d.getHours() ) + ":" + p( d.getMinutes() ) + " UTC" + tz;
+}

--- a/modules/time-shortcode/js/time-shortcode.js
+++ b/modules/time-shortcode/js/time-shortcode.js
@@ -1,3 +1,9 @@
+/**
+ * Get a nice, localized textual representation of a date
+ *
+ * @param date - date object
+ * @return string
+ **/
 var o2_format_date = function ( date ) {
 
 	var time_settings = o2_get_time_settings();

--- a/modules/time-shortcode/js/time-shortcode.js
+++ b/modules/time-shortcode/js/time-shortcode.js
@@ -3,18 +3,23 @@ var o2_parse_date = function ( text ) {
 	return new Date( Date.UTC( +m[1], +m[2] - 1, +m[3], +m[4], +m[5], +m[6] ) );
 }
 
-var o2_format_date = function ( d ) {
+var o2_format_date = function ( date ) {
 
-	var ts = o2_get_time_settings();
+	var time_settings = o2_get_time_settings();
 
-	var p = function( n ) {
+	var zero_prefix = function( n ) {
 		return ( '00' + n ).slice( -2 );
 	};
 
-	var tz = -d.getTimezoneOffset() / 60;
-	if ( tz >= 0 ) {
-		tz = "+" + tz;
+	timezone_offset = -date.getTimezoneOffset() / 60;
+	if( timezone_offset >= 0 ) {
+		timezone_offset = "+" + timezone_offset;
 	}
 
-	return "" + ts['days'][ d.getDay() ] + ", " + ts['months'][ d.getMonth() ] + " " + p( d.getDate() ) + ", " + d.getFullYear() + " " + p( d.getHours() ) + ":" + p( d.getMinutes() ) + " UTC" + tz;
+	return  time_settings['days'][ date.getDay() ] + ", " 
+		+ time_settings['months'][ date.getMonth() ] + " " 
+		+ zero_prefix( date.getDate() ) + ", " 
+		+ date.getFullYear() + " " 
+		+ zero_prefix( date.getHours() ) + ":" + zero_prefix( date.getMinutes() ) 
+		+ " UTC" + timezone_offset;
 }

--- a/modules/time-shortcode/load.php
+++ b/modules/time-shortcode/load.php
@@ -25,19 +25,22 @@ class o2_Time_Shortcode {
 		// try to parse the time, relative to the post/comment time
 		if ( $in_comment_content ) {
 			$date     = strtotime( $comment->comment_date_gmt );
-			$raw_date = date( 'Y-m-d H:i:s', $date );
+			$iso_date = date( 'Y-m-d H:i:s', $date );
 		} else {
 			$post = get_post();
 			$date     = get_the_date( 'U' );
-			$raw_date = $post->post_date_gmt; // already in ISO format
+			$iso_date = $post->post_date_gmt; // already in ISO format
 		}
 
 		$time = self::parse_time( $content, $date );
 
-		// if strtotime doesn't work, try stronger measures
-		if( $time === false || $time === -1 ) {
-			$time = self::parse_time_with_date_parse( $raw_date, $content );
-		}
+		// If strtotime doesn't work, try stronger measures
+		// I havent been able to get this to produce anything close to the real time with invalid input,
+		// which doesn't make it much use as a fallback
+		// Removing it from rotation for now
+		// if( $time === false || $time === -1 ) {
+		//	$time = self::parse_time_with_date_parse( $content, $iso_date );
+		// }
 
 		// if that didn't work, give up
 		if ( $time === false || $time === -1 ) {
@@ -54,32 +57,32 @@ class o2_Time_Shortcode {
 		return $out;
 	}
 
-	public static function parse_time( $date_string, $utc_now ) {
+	public static function parse_time( $date_string, $time ) {
 
-		return strtotime( $date_string, $utc_now );
+		return strtotime( $date_string, $time );
 
 	}
 
-	public static function parse_time_with_date_parse( $raw_date, $content ) {
+	public static function parse_time_with_date_parse( $date_string, $iso_date ) {
 
-			$timearray = date_parse( $content );
-			foreach ( $timearray as $key => $value ) {
-				if ( $value === false ) unset ( $timearray[$key] );
-			}
+		$timearray = date_parse( $date_string );
+		foreach ( $timearray as $key => $value ) {
+			if ( $value === false ) unset ( $timearray[$key] );
+		}
 
-			// merge the info from the post date with this one
-			$relative = date_parse( $raw_date );
-			$timearray = array_merge( $relative, $timearray );
+		// merge the info from the post date with this one
+		$relative = date_parse( $iso_date );
+		$timearray = array_merge( $relative, $timearray );
 
-			// use the blog's timezone if none was specified
-			if ( !isset( $timearray['tz_id'] ) ) {
-				$timearray['tz_id'] = get_option( 'timezone_string' );
-			}
+		// use the blog's timezone if none was specified
+		if ( !isset( $timearray['tz_id'] ) ) {
+			$timearray['tz_id'] = get_option( 'timezone_string' );
+		}
 
-			// build a normalized time string, then parse it to an integer time using strtotime
-			$time = strtotime( "{$timearray['year']}-{$timearray['month']}-{$timearray['day']}T{$timearray['hour']}:{$timearray['minute']}:{$timearray['second']} {$timearray['tz_id']}" );
+		// build a normalized time string, then parse it to an integer time using strtotime
+		$time = strtotime( "{$timearray['year']}-{$timearray['month']}-{$timearray['day']}T{$timearray['hour']}:{$timearray['minute']}:{$timearray['second']} {$timearray['tz_id']}" );
 
-			return $time;
+		return $time;
 	}
 
 	/**

--- a/modules/time-shortcode/load.php
+++ b/modules/time-shortcode/load.php
@@ -24,23 +24,12 @@ class o2_Time_Shortcode {
 
 		// try to parse the time, relative to the post/comment time
 		if ( $in_comment_content ) {
-			$date     = strtotime( $comment->comment_date_gmt );
-			$iso_date = date( 'Y-m-d H:i:s', $date );
+			$relative_time = strtotime( $comment->comment_date_gmt );
 		} else {
-			$post = get_post();
-			$date     = get_the_date( 'U' );
-			$iso_date = $post->post_date_gmt; // already in ISO format
+			$relative_time = get_the_date( 'U' );
 		}
 
-		$time = self::parse_time( $content, $date );
-
-		// If strtotime doesn't work, try stronger measures
-		// I havent been able to get this to produce anything close to the real time with invalid input,
-		// which doesn't make it much use as a fallback
-		// Removing it from rotation for now
-		// if( $time === false || $time === -1 ) {
-		//	$time = self::parse_time_with_date_parse( $content, $iso_date );
-		// }
+		$time = self::parse_time( $content, $relative_time );
 
 		// if that didn't work, give up
 		if ( $time === false || $time === -1 ) {
@@ -75,28 +64,6 @@ class o2_Time_Shortcode {
 
 		return strtotime( $date_string, $time );
 
-	}
-
-	public static function parse_time_with_date_parse( $date_string, $iso_date ) {
-
-		$timearray = date_parse( $date_string );
-		foreach ( $timearray as $key => $value ) {
-			if ( $value === false ) unset ( $timearray[$key] );
-		}
-
-		// merge the info from the post date with this one
-		$relative = date_parse( $iso_date );
-		$timearray = array_merge( $relative, $timearray );
-
-		// use the blog's timezone if none was specified
-		if ( !isset( $timearray['tz_id'] ) ) {
-			$timearray['tz_id'] = get_option( 'timezone_string' );
-		}
-
-		// build a normalized time string, then parse it to an integer time using strtotime
-		$time = strtotime( "{$timearray['year']}-{$timearray['month']}-{$timearray['day']}T{$timearray['hour']}:{$timearray['minute']}:{$timearray['second']} {$timearray['tz_id']}" );
-
-		return $time;
 	}
 
 	/**

--- a/modules/time-shortcode/load.php
+++ b/modules/time-shortcode/load.php
@@ -136,7 +136,8 @@ class o2_Time_Shortcode {
 
 					var $this = jQuery( this );
 
-					var time = $this.data( 'time' );
+					//Valid elements will have an epoch timestamp in milliseconds on a data-time attribute
+					var time = Number.parseInt( $this.data( 'time' ) );
 					if( ! time || isNaN( time ) ){
 						return;
 					}

--- a/modules/time-shortcode/load.php
+++ b/modules/time-shortcode/load.php
@@ -130,7 +130,7 @@ class o2_Time_Shortcode {
 
 				jQuery( 'abbr.globalized-date' ).each( function() {
 
-					$this = jQuery( this );
+					var $this = jQuery( this );
 
 					var parsed_date = o2_parse_date( $this.attr( 'title' ) );
 					if ( parsed_date ) {

--- a/modules/time-shortcode/load.php
+++ b/modules/time-shortcode/load.php
@@ -42,7 +42,7 @@ class o2_Time_Shortcode {
 		$time = self::parse_time( $content, $relative_time );
 
 		// if that didn't work, give up
-		if ( $time === false || $time === -1 ) {
+		if ( false === $time || -1 === $time ) {
 			return $content;
 		}
 
@@ -50,7 +50,7 @@ class o2_Time_Shortcode {
 		$out = '<a href="http://www.timeanddate.com/worldclock/fixedtime.html?iso=' . gmdate( 'Ymd\THi', $time ) . '"><abbr class="globalized-date" title="' . gmdate( 'c', $time ) . '" data-time="' . absint( $time ) . '000">' . $content . '</abbr></a>';
 
 		// add the time converter JS code if not already added
-		if( !has_action( 'wp_footer', array( 'o2_Time_Shortcode', 'time_conversion_script' ) ) ){
+		if ( ! has_action( 'wp_footer', array( 'o2_Time_Shortcode', 'time_conversion_script' ) ) ) {
 			add_action( 'wp_footer', array( 'o2_Time_Shortcode', 'time_conversion_script' ) );
 		}
 
@@ -67,11 +67,11 @@ class o2_Time_Shortcode {
 	 **/
 	public static function parse_time( $date_string, $time = null ) {
 
-		if( empty( $date_string ) ){
+		if ( empty( $date_string ) ) {
 			return false;
 		}
 
-		if( empty( $time ) ){
+		if ( empty( $time ) ) {
 			$time = time();
 		}
 
@@ -101,7 +101,9 @@ class o2_Time_Shortcode {
 		$original_tags = $shortcode_tags;
 
 		// only process the time shortcode
-		$shortcode_tags = array( 'time' => array( 'o2_Time_Shortcode', 'time_shortcode' ) );
+		$shortcode_tags = array(
+			'time' => array( 'o2_Time_Shortcode', 'time_shortcode' ),
+		);
 
 		// do the time shortcode on the comment
 		$comment_text = do_shortcode( $comment_text );
@@ -123,12 +125,12 @@ class o2_Time_Shortcode {
 		?>
 		<script type="text/javascript">
 
-			var o2_get_time_settings = function(){
+			var o2_get_time_settings = function() {
 				return <?php echo json_encode( array(
 					'months' => array_values( $wp_locale->month ),
 					'days'   => array_values( $wp_locale->weekday ),
 				) ); ?>;
-			}
+			};
 
 			jQuery( 'body' ).on( 'ready post-load ready.o2', function() {
 
@@ -138,7 +140,7 @@ class o2_Time_Shortcode {
 
 					//Valid elements will have an epoch timestamp in milliseconds on a data-time attribute
 					var time = Number.parseInt( $this.data( 'time' ) );
-					if( ! time || isNaN( time ) ){
+					if( ! time || isNaN( time ) ) {
 						return;
 					}
 

--- a/modules/time-shortcode/load.php
+++ b/modules/time-shortcode/load.php
@@ -98,7 +98,7 @@ class o2_Time_Shortcode {
 		$original_tags = $shortcode_tags;
 
 		// only process the time shortcode
-		$shortcode_tags = array( 'time' => 'o2_time_shortcode' );
+		$shortcode_tags = array( 'time' => array( 'o2_Time_Shortcode', 'time_shortcode' ) );
 
 		// do the time shortcode on the comment
 		$comment_text = do_shortcode( $comment_text );

--- a/modules/time-shortcode/load.php
+++ b/modules/time-shortcode/load.php
@@ -4,6 +4,8 @@
  * Original Author: Otto
  *
  * Usage: [time]any-valid-time-string-here[/time]
+ * Put any attribute into the shortcode to have a date relative to the current time instead of the post/comment time
+ * e.g. [time doitlive]any-valid-time-string-here[/time]
  * Will attempt to parse the time string and create a format that shows it in the viewers local time zone
  * Note that times should be complete with year, month, day, and hour and minute.. something strtotime can parse meaningfully.
  * Times are assumed to be UTC.
@@ -24,7 +26,7 @@ class o2_Time_Shortcode {
 	/**
 	 * Process the time shortcode
 	 *
-	 * @param array $attr (unused)
+	 * @param array $attr - parse relative to current time if any attribute is set
 	 * @param string $content - Any valid strtotime string
 	 * @return string - html content
 	 **/
@@ -32,8 +34,10 @@ class o2_Time_Shortcode {
 
 		global $in_comment_content, $comment;
 
-		// try to parse the time, relative to the post/comment time
-		if ( $in_comment_content ) {
+		// try to parse the time, relative to now or comment time or post time, in that order
+		if( ! empty( $attr ) ) {
+			$relative_time = false;
+		} elseif ( $in_comment_content ) {
 			$relative_time = strtotime( $comment->comment_date_gmt );
 		} else {
 			$relative_time = get_the_date( 'U' );

--- a/modules/time-shortcode/load.php
+++ b/modules/time-shortcode/load.php
@@ -79,6 +79,9 @@ class o2_Time_Shortcode {
 			$time = time();
 		}
 
+		// Remove the word "at" from the string, if present. Allows strings like "Monday, April 6 at 19:00 UTC" to work
+		$date_string = str_replace( ' at ', ' ', $date_string );
+
 		// Convert all the random characters to html entities, then strip all html entities
 		// This removes both bad unicode characters and html entities in one swoop
 		// .+-/ characters are unnaffected by htmlentities, so strtotime won't break

--- a/modules/time-shortcode/load.php
+++ b/modules/time-shortcode/load.php
@@ -12,12 +12,22 @@
 
 class o2_Time_Shortcode {
 
+	/**
+	 * Set the hooks for handling the time shortcode
+	 **/
 	public static function init() {
 
 		add_shortcode( 'time', array( 'o2_Time_Shortcode', 'time_shortcode' ) );
 		add_filter( 'comment_text', array( 'o2_Time_Shortcode', 'do_comment_time_shortcode' ) );
 	}
 
+	/**
+	 * Process the time shortcode
+	 *
+	 * @param array $attr (unused)
+	 * @param string $content - Any valid strtotime string
+	 * @return string - html content
+	 **/
 	public static function time_shortcode( $attr, $content = null ) {
 
 		global $in_comment_content, $comment;
@@ -48,6 +58,13 @@ class o2_Time_Shortcode {
 		return $out;
 	}
 
+	/**
+	 * Convert a time string into an epoch timestamp
+	 *
+	 * @param string $date_string - Any valid strtotime string
+	 * @param int $time (optional) - Epoch timestamp for relative date parsing
+	 * @return mixed - int Epoch timestamp on success, false on fail
+	 **/
 	public static function parse_time( $date_string, $time = null ) {
 
 		if( empty( $date_string ) ){
@@ -69,7 +86,7 @@ class o2_Time_Shortcode {
 	/**
 	 * Process the time shortcode and only the time shortcode in comments
 	 *
-	 * @param string $comment_text The comment content
+	 * @param string $comment_text - The comment content
 	 * @return string Modified comment content
 	 **/
 	public static function do_comment_time_shortcode( $comment_text ) {
@@ -93,6 +110,9 @@ class o2_Time_Shortcode {
 		return $comment_text;
 	}
 
+	/**
+	 * Render and enqueue the javascript that converts the raw time into local time
+	 **/
 	public static function time_conversion_script() {
 
 		global $wp_locale; // These are strings that Core has already translated.

--- a/modules/time-shortcode/load.php
+++ b/modules/time-shortcode/load.php
@@ -113,43 +113,42 @@ class o2_Time_Shortcode {
 	}
 
 	public static function time_conversion_script() {
+
 		global $wp_locale; // These are strings that Core has already translated.
+
 		?>
 		<script type="text/javascript">
-		( function( $ ) {
 
-			var ts = <?php echo json_encode( array(
-				'months' => array_values( $wp_locale->month ),
-				'days'   => array_values( $wp_locale->weekday ),
-			) ); ?>;
-
-			var o2_parse_date = function ( text ) {
-				var m = /^([0-9]{4})-([0-9]{2})-([0-9]{2})T([0-9]{2}):([0-9]{2}):([0-9]{2})\+00:00$/.exec( text );
-				return new Date( Date.UTC( +m[1], +m[2] - 1, +m[3], +m[4], +m[5], +m[6] ) );
-			}
-			var o2_format_date = function ( d ) {
-				var p = function( n ) {
-					return ( '00' + n ).slice( -2 );
-				};
-				var tz = -d.getTimezoneOffset() / 60;
-				if ( tz >= 0 ) {
-					tz = "+" + tz;
-				}
-				return "" + ts['days'][ d.getDay() ] + ", " + ts['months'][ d.getMonth() ] + " " + p( d.getDate() ) + ", " + d.getFullYear() + " " + p( d.getHours() ) + ":" + p( d.getMinutes() ) + " UTC" + tz;
+			var o2_get_time_settings = function(){
+				return <?php echo json_encode( array(
+					'months' => array_values( $wp_locale->month ),
+					'days'   => array_values( $wp_locale->weekday ),
+				) ); ?>;
 			}
 
-			$( 'body' ).on( 'ready post-load ready.o2', function() {
-				$( 'abbr.globalized-date' ).each( function() {
-					t = $( this );
-					var d = o2_parse_date( t.attr( 'title' ) );
-					if ( d ) {
-						t.text( o2_format_date( d ) );
+			jQuery( 'body' ).on( 'ready post-load ready.o2', function() {
+
+				jQuery( 'abbr.globalized-date' ).each( function() {
+
+					$this = jQuery( this );
+
+					var parsed_date = o2_parse_date( $this.attr( 'title' ) );
+					if ( parsed_date ) {
+						$this.text( o2_format_date( parsed_date ) );
 					}
 				} );
 			} );
-		} )( jQuery );
+
 		</script>
 		<?php
+
+		wp_enqueue_script(
+			'o2-time-shortcode',
+			plugins_url( 'modules/time-shortcode/js/time-shortcode.js', O2__FILE__ ),
+			array(),
+			1.1,
+			true
+		);
 	}
 }
 o2_Time_Shortcode::init();

--- a/modules/time-shortcode/load.php
+++ b/modules/time-shortcode/load.php
@@ -50,14 +50,28 @@ class o2_Time_Shortcode {
 		// build the link and abbr microformat
 		$out = '<a href="http://www.timeanddate.com/worldclock/fixedtime.html?iso=' . gmdate( 'Ymd\THi', $time ) . '"><abbr class="globalized-date" title="' . gmdate( 'c', $time ) . '" data-time="' . absint( $time ) . '000">' . $content . '</abbr></a>';
 
-		// add the time converter JS code
-		add_action( 'wp_footer', array( 'o2_Time_Shortcode', 'time_conversion_script' ) );
+		// add the time converter JS code if not already added
+		if( !has_action( 'wp_footer', array( 'o2_Time_Shortcode', 'time_conversion_script' ) ) ){
+			add_action( 'wp_footer', array( 'o2_Time_Shortcode', 'time_conversion_script' ) );
+		}
 
 		// return the new link
 		return $out;
 	}
 
-	public static function parse_time( $date_string, $time ) {
+	public static function parse_time( $date_string, $time = null ) {
+
+		if( empty( $date_string ) ){
+			return false;
+		}
+
+		if( empty( $time ) ){
+			$time = time();
+		}
+
+		$html_entity_regex = '/&[^\s]*;/';
+		$date_string = preg_replace( $html_entity_regex, ' ', $date_string );
+		$date_string = str_ireplace( "U+00A0", ' ', $date_string );
 
 		return strtotime( $date_string, $time );
 

--- a/modules/time-shortcode/load.php
+++ b/modules/time-shortcode/load.php
@@ -133,7 +133,7 @@ class o2_Time_Shortcode {
 					var $this = jQuery( this );
 
 					var time = $this.data( 'time' );
-					if( isNaN( time ) ){
+					if( ! time || isNaN( time ) ){
 						return;
 					}
 

--- a/modules/time-shortcode/load.php
+++ b/modules/time-shortcode/load.php
@@ -146,7 +146,7 @@ class o2_Time_Shortcode {
 					var $this = jQuery( this );
 
 					//Valid elements will have an epoch timestamp in milliseconds on a data-time attribute
-					var time = Number.parseInt( $this.data( 'time' ) );
+					var time = parseInt( $this.data( 'time' ), 10 );
 					if( ! time || isNaN( time ) ) {
 						return;
 					}

--- a/modules/time-shortcode/load.php
+++ b/modules/time-shortcode/load.php
@@ -11,12 +11,12 @@
  **/
 
 function o2_time_shortcode( $attr, $content = null ) {
-	global $post, $time_in_comments, $comment;
+	global $post, $in_comment_content, $comment;
 	$post = get_post();
 
 	// try to parse the time, relative to the post/comment time
 
-	if ( $time_in_comments ) {
+	if ( $in_comment_content ) {
 		$date     = strtotime( $comment->comment_date_gmt );
 		$raw_date = date( 'Y-m-d H:i:s', $date );
 	} else {
@@ -65,6 +65,7 @@ function o2_time_converter_script() {
 ?>
 	<script type="text/javascript">
 	( function( $ ) {
+
 		var ts = <?php echo json_encode( array(
 			'months' => array_values( $wp_locale->month ),
 			'days'   => array_values( $wp_locale->weekday ),
@@ -100,24 +101,30 @@ function o2_time_converter_script() {
 }
 add_shortcode( 'time', 'o2_time_shortcode' );
 
-function o2_time_shortcode_in_comments( $comment ) {
-	global $shortcode_tags, $post, $time_in_comments;
-	$time_in_comments = true;
-	$post = get_post();
+/**
+ * Process the time shortcode and only the time shortcode in comments
+ *
+ * @param string $comment_text The comment content
+ * @return string Modified comment content
+ **/
+function o2_time_shortcode_in_comments( $comment_text ) {
+
+	global $shortcode_tags, $in_comment_content;
+	$in_comment_content = true;
 
 	// save the shortcodes
-	$saved_tags = $shortcode_tags;
+	$original_tags = $shortcode_tags;
 
 	// only process the time shortcode
 	$shortcode_tags = array( 'time' => 'o2_time_shortcode' );
 
 	// do the time shortcode on the comment
-	$comment = do_shortcode( $comment );
+	$comment_text = do_shortcode( $comment_text );
 
 	// restore the normal shortcodes
-	$shortcode_tags = $saved_tags;
+	$shortcode_tags = $original_tags;
 
-	$time_in_comments = false;
-	return $comment;
+	$in_comment_content = false;
+	return $comment_text;
 }
 add_filter( 'comment_text', 'o2_time_shortcode_in_comments' );

--- a/modules/time-shortcode/load.php
+++ b/modules/time-shortcode/load.php
@@ -48,7 +48,7 @@ class o2_Time_Shortcode {
 		}
 
 		// build the link and abbr microformat
-		$out = '<a href="http://www.timeanddate.com/worldclock/fixedtime.html?iso=' . gmdate( 'Ymd\THi', $time ) . '"><abbr class="globalized-date" title="' . gmdate( 'c', $time ) . '">' . $content . '</abbr></a>';
+		$out = '<a href="http://www.timeanddate.com/worldclock/fixedtime.html?iso=' . gmdate( 'Ymd\THi', $time ) . '"><abbr class="globalized-date" title="' . gmdate( 'c', $time ) . '" data-time="' . absint( $time ) . '000">' . $content . '</abbr></a>';
 
 		// add the time converter JS code
 		add_action( 'wp_footer', array( 'o2_Time_Shortcode', 'time_conversion_script' ) );
@@ -132,10 +132,14 @@ class o2_Time_Shortcode {
 
 					var $this = jQuery( this );
 
-					var parsed_date = o2_parse_date( $this.attr( 'title' ) );
-					if ( parsed_date ) {
-						$this.text( o2_format_date( parsed_date ) );
+					var time = $this.data( 'time' );
+					if( isNaN( time ) ){
+						return;
 					}
+
+					var date = new Date( time );
+					$this.text( o2_format_date( date ) );
+
 				} );
 			} );
 

--- a/modules/time-shortcode/load.php
+++ b/modules/time-shortcode/load.php
@@ -75,9 +75,12 @@ class o2_Time_Shortcode {
 			$time = time();
 		}
 
+		// Convert all the random characters to html entities, then strip all html entities
+		// This removes both bad unicode characters and html entities in one swoop
+		// .+-/ characters are unnaffected by htmlentities, so strtotime won't break
+		$date_string = htmlentities( $date_string, ENT_QUOTES );
 		$html_entity_regex = '/&[^\s]*;/';
 		$date_string = preg_replace( $html_entity_regex, ' ', $date_string );
-		$date_string = str_ireplace( "U+00A0", ' ', $date_string );
 
 		return strtotime( $date_string, $time );
 

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -10,5 +10,8 @@
 		<testsuite>
 			<directory prefix="test-" suffix=".php">./tests/phpunit/</directory>
 		</testsuite>
+		<testsuite>
+			<directory prefix="test-" suffix=".php">./tests/phpunit/modules</directory>
+		</testsuite>
 	</testsuites>
 </phpunit>

--- a/tests/phpunit/modules/test-time-shortcode.php
+++ b/tests/phpunit/modules/test-time-shortcode.php
@@ -2,6 +2,10 @@
 
 class TimeShortcodeTest extends WP_UnitTestCase {
 
+	/**
+	* Time Parser tests
+	*/
+
 	function test_parse_time_now() {
 
 		$time_string = 'now';
@@ -152,5 +156,50 @@ class TimeShortcodeTest extends WP_UnitTestCase {
 			'Time parser should handle U+00A0 gracefully'
 		);
 	}
+
+	/**
+	* Module logic tests
+	**/
+
+	function test_shortcode_processed() {
+
+		global $post;
+
+		$post_id = $this->factory->post->create( array(
+			'post_title' => 'Test Post',
+			'post_content' => 'This is some [time]April 2 2009 2:00 PM[/time] test content.'
+		));
+
+		$post = get_post( $post_id );
+		setup_postdata( $post );
+
+		$content = apply_filters( 'the_content', get_the_content() );
+
+		$this->assertFalse(
+			stripos( $content, "[time]" ),
+			'Time shortcode should get processed in post content'
+		);
+	}
+
+	function test_comment_shortcode_processed() {
+
+		global $comment;
+
+		$comment_id = $this->factory->comment->create( array(
+			'comment_content' => 'Test [time]April 2 2009 2:00 PM[/time] comment content',
+			'comment_approved' => 1
+		));
+
+		$the_comment = get_comment( $comment_id );
+		$comment = $the_comment;
+
+		$content = apply_filters( 'comment_text', $the_comment->comment_content );
+
+		$this->assertFalse(
+			stripos( $content, "[time]" ),
+			'Time shortcode should get processed in comment content'
+		);
+	}
+
 }
 

--- a/tests/phpunit/modules/test-time-shortcode.php
+++ b/tests/phpunit/modules/test-time-shortcode.php
@@ -171,6 +171,18 @@ class TimeShortcodeTest extends WP_UnitTestCase {
 		);
 	}
 
+	function test_parse_time_with_at() {
+
+		$time_string = 'April 2 2009 at 2:00 PM';
+
+		$parsed_time = o2_Time_Shortcode::parse_time( $time_string );
+
+		$this->assertEquals(
+			1238680800, $parsed_time,
+			'Time parser should handle the word "at"'
+		);
+	}
+
 	/**
 	* Module logic tests
 	**/

--- a/tests/phpunit/modules/test-time-shortcode.php
+++ b/tests/phpunit/modules/test-time-shortcode.php
@@ -215,4 +215,33 @@ class TimeShortcodeTest extends WP_UnitTestCase {
 		);
 	}
 
+
+	function test_relative_shortcode_arg_processed() {
+
+		global $post;
+
+		$post_id = $this->factory->post->create( array(
+			'post_title' => 'Test Post',
+			'post_content' => 'This is some [time now]+2 days[/time] test content.',
+			'post_date' => '2000-01-01 02:00:00',
+			'post_date_gmt' => '2000-01-01 02:00:00'
+		));
+
+		$post = get_post( $post_id );
+		setup_postdata( $post );
+
+		$result = o2_Time_Shortcode::time_shortcode( array(), '+2 days' );
+		$this->assertTrue(
+			(bool) strpos( $result, "946864800000"),
+			'Time shortcode should parse relative to post time when no args in shortcode'
+		);
+
+		$result = o2_Time_Shortcode::time_shortcode( array( 'now' ), '+2 days' );
+		$this->assertFalse(
+			(bool) strpos( $result, "946864800000"),
+			'Time shortcode should parse relative to now when no args in shortcode'
+		);
+
+	}
+
 }

--- a/tests/phpunit/modules/test-time-shortcode.php
+++ b/tests/phpunit/modules/test-time-shortcode.php
@@ -1,0 +1,13 @@
+<?php
+
+class TimeShortcodeTest extends WP_UnitTestCase {
+
+	function test_test() {
+
+		$this->assertTrue( 
+			true
+		);
+	}
+
+}
+

--- a/tests/phpunit/modules/test-time-shortcode.php
+++ b/tests/phpunit/modules/test-time-shortcode.php
@@ -13,9 +13,22 @@ class TimeShortcodeTest extends WP_UnitTestCase {
 
 		$parsed_time = o2_Time_Shortcode::parse_time( $time_string );
 
-		$this->assertEquals( 
-			$epoch_now, $parsed_time,
+		//Allow 1 second max difference in case time has changed since the test started
+		$this->assertLessThanOrEqual( 
+			1, $parsed_time - $epoch_now,
 			'Time parser should handle "Now"'
+		);
+	}
+
+	function test_parse_time_now_relative() {
+
+		$time_string = 'now';
+
+		$parsed_time = o2_Time_Shortcode::parse_time( $time_string, 968544000 );
+
+		$this->assertEquals( 
+			968544000, $parsed_time,
+			'Time parser should handle "Now" relative to some timestamp'
 		);
 	}
 

--- a/tests/phpunit/modules/test-time-shortcode.php
+++ b/tests/phpunit/modules/test-time-shortcode.php
@@ -2,11 +2,44 @@
 
 class TimeShortcodeTest extends WP_UnitTestCase {
 
-	function test_test() {
+	function test_parse_time_now() {
 
-		$this->assertTrue( 
-			true
+		$time_string = 'now';
+		$epoch_now = date( 'U' );
+
+		$parsed_time = o2_Time_Shortcode::parse_time( $time_string, $epoch_now );
+
+		$this->assertEquals( 
+			$epoch_now, $parsed_time,
+			'Time parser should handle "Now"'
 		);
+	}
+
+	function test_parse_time_date() {
+
+		$time_string = '10 September 2000';
+		$epoch_now = date( 'U' );
+
+		$parsed_time = o2_Time_Shortcode::parse_time( $time_string, $epoch_now );
+
+		$this->assertEquals(
+			968544000, $parsed_time,
+			'Time parser should handle specific dates'
+		);
+	}
+
+	function test_parse_time_invalid() {
+
+		$time_string = '12 Bananuary 2015';
+		$epoch_now = date( 'U' );
+
+		$parsed_time = o2_Time_Shortcode::parse_time( $time_string, $epoch_now );
+
+		$this->assertFalse(
+			$parsed_time,
+			'Time parser should reject made up dates'
+		);
+
 	}
 
 }

--- a/tests/phpunit/modules/test-time-shortcode.php
+++ b/tests/phpunit/modules/test-time-shortcode.php
@@ -7,7 +7,7 @@ class TimeShortcodeTest extends WP_UnitTestCase {
 		$time_string = 'now';
 		$epoch_now = date( 'U' );
 
-		$parsed_time = o2_Time_Shortcode::parse_time( $time_string, $epoch_now );
+		$parsed_time = o2_Time_Shortcode::parse_time( $time_string );
 
 		$this->assertEquals( 
 			$epoch_now, $parsed_time,
@@ -18,9 +18,8 @@ class TimeShortcodeTest extends WP_UnitTestCase {
 	function test_parse_time_date() {
 
 		$time_string = '10 September 2000';
-		$epoch_now = date( 'U' );
 
-		$parsed_time = o2_Time_Shortcode::parse_time( $time_string, $epoch_now );
+		$parsed_time = o2_Time_Shortcode::parse_time( $time_string );
 
 		$this->assertEquals(
 			968544000, $parsed_time,
@@ -28,12 +27,36 @@ class TimeShortcodeTest extends WP_UnitTestCase {
 		);
 	}
 
+	function test_parse_time_american() {
+
+		$time_string = '9/10/00';
+
+		$parsed_time = o2_Time_Shortcode::parse_time( $time_string );
+
+		$this->assertEquals(
+			968544000, $parsed_time,
+			'Time parser should handle American-style dates'
+		);
+	}
+
+	function test_parse_time_european() {
+
+		$time_string = '10-09-2000';
+
+		$parsed_time = o2_Time_Shortcode::parse_time( $time_string );
+
+		$this->assertEquals(
+			968544000, $parsed_time,
+			'Time parser should handle European-style dates'
+		);
+
+	}
+
 	function test_parse_time_invalid() {
 
 		$time_string = '12 Bananuary 2015';
-		$epoch_now = date( 'U' );
 
-		$parsed_time = o2_Time_Shortcode::parse_time( $time_string, $epoch_now );
+		$parsed_time = o2_Time_Shortcode::parse_time( $time_string );
 
 		$this->assertFalse(
 			$parsed_time,
@@ -42,5 +65,92 @@ class TimeShortcodeTest extends WP_UnitTestCase {
 
 	}
 
+	function test_parse_time_null() {
+
+		$time_string = null;
+
+		$parsed_time = o2_Time_Shortcode::parse_time( $time_string );
+
+		$this->assertFalse(
+			$parsed_time,
+			'Time parser should reject null'
+		);
+
+	}
+
+	function test_parse_time_empty_string() {
+
+		$time_string = "";
+
+		$parsed_time = o2_Time_Shortcode::parse_time( $time_string );
+
+		$this->assertFalse(
+			$parsed_time,
+			'Time parser should reject empty string'
+		);
+	}
+
+	function test_parse_time_relative_to_timestamp() {
+
+		$time_string = "next Tuesday";
+		$reference_date = 968544000; //Sunday 10 September 2000
+		$next_tuesday = 968544000 + (60*60*24*2);
+
+		$parsed_time = o2_Time_Shortcode::parse_time( $time_string, $reference_date );
+
+		$this->assertEquals(
+			$next_tuesday, $parsed_time,
+			'Time parser should handle relative dates'
+		);
+	}
+
+	function test_parse_time_relative_to_timestamp_with_plus() {
+
+		$time_string = "+2 days";
+		$reference_date = 968544000; //Sunday 10 September 2000
+		$next_tuesday = 968544000 + (60*60*24*2);
+
+		$parsed_time = o2_Time_Shortcode::parse_time( $time_string, $reference_date );
+
+		$this->assertEquals(
+			$next_tuesday, $parsed_time,
+			'Time parser should handle relative dates'
+		);
+	}
+
+	function test_parse_time_extra_whitespace() {
+		$time_string = '10     September 		2000';
+
+		$parsed_time = o2_Time_Shortcode::parse_time( $time_string );
+
+		$this->assertEquals(
+			968544000, $parsed_time,
+			'Time parser should handle extra whitespace gracefully'
+		);
+	}
+
+	function test_parse_time_nbsp() {
+
+		$time_string = '10 &nbsp;September 2000';
+
+		$parsed_time = o2_Time_Shortcode::parse_time( $time_string );
+
+		$this->assertEquals(
+			968544000, $parsed_time,
+			'Time parser should handle &nbsp; gracefully'
+		);
+	}
+
+	function test_parse_time_U00A0() {
+
+		$time_string = '10 SeptemberU+00A0 2000';
+
+		$parsed_time = o2_Time_Shortcode::parse_time( $time_string );
+
+		$this->assertEquals(
+			968544000, $parsed_time,
+			'Time parser should handle U+00A0 gracefully'
+		);
+	}
 }
 

--- a/tests/phpunit/modules/test-time-shortcode.php
+++ b/tests/phpunit/modules/test-time-shortcode.php
@@ -14,7 +14,7 @@ class TimeShortcodeTest extends WP_UnitTestCase {
 		$parsed_time = o2_Time_Shortcode::parse_time( $time_string );
 
 		//Allow 1 second max difference in case time has changed since the test started
-		$this->assertLessThanOrEqual( 
+		$this->assertLessThanOrEqual(
 			1, $parsed_time - $epoch_now,
 			'Time parser should handle "Now"'
 		);
@@ -26,7 +26,7 @@ class TimeShortcodeTest extends WP_UnitTestCase {
 
 		$parsed_time = o2_Time_Shortcode::parse_time( $time_string, 968544000 );
 
-		$this->assertEquals( 
+		$this->assertEquals(
 			968544000, $parsed_time,
 			'Time parser should handle "Now" relative to some timestamp'
 		);
@@ -111,7 +111,7 @@ class TimeShortcodeTest extends WP_UnitTestCase {
 
 		$time_string = "next Tuesday";
 		$reference_date = 968544000; //Sunday 10 September 2000
-		$next_tuesday = 968544000 + (60*60*24*2);
+		$next_tuesday = 968544000 + ( 60*60*24*2 );
 
 		$parsed_time = o2_Time_Shortcode::parse_time( $time_string, $reference_date );
 
@@ -125,7 +125,7 @@ class TimeShortcodeTest extends WP_UnitTestCase {
 
 		$time_string = "+2 days";
 		$reference_date = 968544000; //Sunday 10 September 2000
-		$next_tuesday = 968544000 + (60*60*24*2);
+		$next_tuesday = 968544000 + ( 60*60*24*2 );
 
 		$parsed_time = o2_Time_Shortcode::parse_time( $time_string, $reference_date );
 
@@ -216,4 +216,3 @@ class TimeShortcodeTest extends WP_UnitTestCase {
 	}
 
 }
-

--- a/tests/phpunit/modules/test-time-shortcode.php
+++ b/tests/phpunit/modules/test-time-shortcode.php
@@ -147,13 +147,14 @@ class TimeShortcodeTest extends WP_UnitTestCase {
 
 	function test_parse_time_U00A0() {
 
-		$time_string = '10 SeptemberU+00A0 2000';
+		//Add a unicode nbsp in the middle of the string
+		$time_string = '10 September'.json_decode('"\u00A0"').' 2000';
 
 		$parsed_time = o2_Time_Shortcode::parse_time( $time_string );
 
 		$this->assertEquals(
 			968544000, $parsed_time,
-			'Time parser should handle U+00A0 gracefully'
+			'Time parser should handle unicode nbsp gracefully'
 		);
 	}
 

--- a/tests/qunit/index.html
+++ b/tests/qunit/index.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html>
+	<head>
+		<meta charset="utf-8">
+		<meta name="viewport" content="width=device-width">
+		<title>o2 QUnit Test Suite</title>
+		<link rel="stylesheet" href="https://code.jquery.com/qunit/qunit-2.0.1.css">
+
+		<!-- General Dependencies -->
+		<script src="../../../../../wp-includes/js/jquery/jquery.js"></script>
+
+		<!-- 
+		These other ones aren't needed yet, but may be down the line
+		<script src="../../../../../wp-includes/js/jquery/ui/core.js"></script>
+		<script src="../../../../../wp-includes/js/underscore.min.js"></script>
+		<script src="../../../../../wp-includes/js/backbone.min.js"></script>
+		<script src="../../../../../wp-includes/js/wp-backbone.js"></script>
+		<script src="../../../../../wp-includes/js/wp-util.js"></script>
+		-->
+
+		<!-- Plugin Dependencies -->
+		<script src="../../modules/time-shortcode/js/time-shortcode.js"></script>
+
+	</head>
+
+	<body>
+		<div id="qunit"></div>
+		<div id="qunit-fixture"></div>
+
+		<script src="https://code.jquery.com/qunit/qunit-2.0.1.js"></script>
+		<script>QUnit.config.hidepassed = false;</script>
+
+		<!-- Test Suites -->
+		<script src="modules/time-shortcode.js"></script>
+	</body>
+</html>

--- a/tests/qunit/modules/time-shortcode.js
+++ b/tests/qunit/modules/time-shortcode.js
@@ -1,0 +1,42 @@
+QUnit.module( 'Time Shortcode' );
+
+//Set up the time settings function manually since PHP usually generates it
+var o2_get_time_settings = function(){
+	return { 
+		"months": [
+				"January",
+				"February",
+				"March",
+				"April",
+				"May",
+				"June",
+				"July",
+				"August",
+				"September",
+				"October",
+				"November",
+				"December"
+		],
+		"days": [
+				"Sunday",
+				"Monday",
+				"Tuesday",
+				"Wednesday",
+				"Thursday",
+				"Friday",
+				"Saturday"
+		]
+	};
+}
+
+QUnit.test( "o2_parse_date valid date", function( assert ) {
+
+	var date_string = "2016-09-30T12:00:00+00:00";
+
+	var date_object = o2_parse_date( date_string );
+
+  	assert.ok( 
+		date_object.toISOString().indexOf( "2016-09-30T12:00:00" ) != -1, 
+		"Correct date value should be parsed on valid input" 
+	);
+});

--- a/tests/qunit/modules/time-shortcode.js
+++ b/tests/qunit/modules/time-shortcode.js
@@ -73,18 +73,6 @@ function DateMock( weekday, day, month, year, hour, minute, timezone_offset ) {
 	}
 };
 
-QUnit.test( "o2_parse_date valid date", function( assert ) {
-
-	var date_string = "2016-09-30T12:00:00+00:00";
-
-	var date_object = o2_parse_date( date_string );
-
-  	assert.ok( 
-		date_object.toISOString().indexOf( "2016-09-30T12:00:00" ) != -1, 
-		"Correct date value should be parsed on valid input" 
-	);
-});
-
 QUnit.test( "o2_format_date: valid gmt date", function( assert ) {
 
 	var date = new DateMock( 1, 3, 9, 2016, 1, 30, 0 ); // Mon, 03 Oct 2016 01:30 UTC

--- a/tests/qunit/modules/time-shortcode.js
+++ b/tests/qunit/modules/time-shortcode.js
@@ -29,6 +29,50 @@ var o2_get_time_settings = function(){
 	};
 }
 
+/**
+ * A spoof of the Date object
+ * Use this instead of normal Date objects to have exact control over the timezone and other properties
+ * @param weekday - integer day of the week (0-6)
+ * @param day - integer day of the month (1-31)
+ * @param month - integer month of the year (0-11)
+ * @param year - integer 4-digit full year (e.g. 2016)
+ * @param hour - integer hour of the day (0-23)
+ * @param minute - integer minute of the hour (0-59)
+ * @param timezone_offset - integer timezone offset in minutes (e.g. 480 )
+ **/
+function DateMock( weekday, day, month, year, hour, minute, timezone_offset ) {
+
+	this.weekday = weekday;
+	this.day = day;
+	this.month = month;
+	this.year = year;
+	this.hour = hour;
+	this.minute = minute;
+	this.timezone_offset = timezone_offset;
+
+	this.getDay = function(){
+		return this.weekday;
+	}
+	this.getMonth = function(){
+		return this.month;
+	}
+	this.getDate = function(){
+		return this.day;
+	}
+	this.getFullYear = function(){
+		return this.year;
+	}
+	this.getHours = function(){
+		return this.hour;
+	}
+	this.getMinutes = function(){
+		return this.minute;
+	}
+	this.getTimezoneOffset = function(){
+		return this.timezone_offset;
+	}
+};
+
 QUnit.test( "o2_parse_date valid date", function( assert ) {
 
 	var date_string = "2016-09-30T12:00:00+00:00";
@@ -38,5 +82,36 @@ QUnit.test( "o2_parse_date valid date", function( assert ) {
   	assert.ok( 
 		date_object.toISOString().indexOf( "2016-09-30T12:00:00" ) != -1, 
 		"Correct date value should be parsed on valid input" 
+	);
+});
+
+QUnit.test( "o2_format_date: valid gmt date", function( assert ) {
+
+	var date = new DateMock( 1, 3, 9, 2016, 1, 30, 0 ); // Mon, 03 Oct 2016 01:30 UTC
+
+	assert.equal(
+		o2_format_date( date ), "Monday, October 03, 2016 01:30 UTC+0",
+		"Correct date should return for GMC timezone"
+	);
+
+});
+
+QUnit.test( "o2_format_date: valid, negative-offset date", function( assert ) {
+
+	var date = new DateMock( 4, 22, 2, 2015, 20, 12, 480 ); // Thur, 22 Mar 2015 20:12 UTC-8
+
+	assert.equal(
+		o2_format_date( date ), "Thursday, March 22, 2015 20:12 UTC-8",
+		"Correct date should return for negative UTC timezone"
+	);
+});
+
+QUnit.test( "o2_format_date: valid, positive-offset date", function( assert ) {
+
+	var date = new DateMock( 0, 12, 0, 2012, 12, 00, -120 ); // Sun, 12 Jan 2012 12:00 UTC+2
+
+	assert.equal(
+		o2_format_date( date ), "Sunday, January 12, 2012 12:00 UTC+2",
+		"Correct date should return for positive UTC timezone"
 	);
 });


### PR DESCRIPTION
I've refactored the time shortcode module to make it more robust and unit-testable, as well as unit testing the module.

I've also set up a basic QUnit implementation to enable testing of the time shortcode module javascript and other javascript from the plugin.