### PR TITLE
Use nicenames in classes and selectors

### DIFF
--- a/inc/fragment.php
+++ b/inc/fragment.php
@@ -404,7 +404,7 @@ class o2_Fragment {
 
 	/**
 	  * get_current_user_properties returns
-	  * 	userLogin, canEditPosts, canEditOthersPosts, and canPublishPosts for logged in user
+	  * 	userLogin, userNicename, canEditPosts, canEditOthersPosts, and canPublishPosts for logged in user
 	  * OR
 	  * 	noprivUserName, noprivUserHash and noprivUserURL for nopriv user
 	  *
@@ -424,6 +424,7 @@ class o2_Fragment {
 
 				$return_result = array(
 					'userLogin' => $user_data->user_login,
+					'userNicename' => $user_data->user_nicename,
 					'noprivUserName' => '',
 					'noprivUserHash' => '',
 					'noprivUserURL' => '',
@@ -441,6 +442,7 @@ class o2_Fragment {
 
 		$return_result = array(
 			'userLogin' => '',
+			'userNicename' => '',
 			'noprivUserName' => esc_attr( $commenter['comment_author'] ),
 			'noprivUserEmail' => esc_attr( $commenter['comment_author_email'] ),
 			'noprivUserURL' => esc_url( $commenter['comment_author_url'] ),
@@ -472,6 +474,7 @@ class o2_Fragment {
 			'id' => $user_data->ID,
 			'type' => 'user',
 			'userLogin' => $user_data->user_login,
+			'userNicename' => $user_data->user_nicename,
 			'displayName' => $user_data->display_name,
 			'firstName' => $user_data->user_firstname,
 			'lastName' => $user_data->user_lastname,
@@ -500,7 +503,8 @@ class o2_Fragment {
 		self::add_to_user_bootstrap( $user_data );
 
 		$return_result = array(
-			'userLogin' => $user_data->user_login
+			'userLogin' => $user_data->user_login,
+			'userNicename' => $user_data->user_nicename
 		);
 
 		return $return_result;
@@ -515,7 +519,8 @@ class o2_Fragment {
 			self::add_to_user_bootstrap( $user_data );
 
 			$return_result = array(
-				'userLogin' => $user_data->user_login
+				'userLogin' => $user_data->user_login,
+				'userNicename' => $user_data->user_nicename
 			);
 		} else { // no priv commentor
 			$comment_author_email_hash = !empty( $_comment->comment_author_email ) ? md5( strtolower( trim( $_comment->comment_author_email ) ) ) : '00000000000000000000000000000000';

--- a/js/app/main.js
+++ b/js/app/main.js
@@ -133,7 +133,7 @@ o2.Routers.App = ( function( $, Backbone ) {
 			} );
 
 			o2.Events.doAction( 'pre-postsView-render.o2' );
-			o2.$appContainer.addClass( 'current-user-' + o2.currentUser.userLogin ).append( this.postsView.render().el );
+			o2.$appContainer.addClass( 'current-user-' + o2.currentUser.userNicename ).append( this.postsView.render().el );
 			o2.Events.doAction( 'post-postsView-render.o2' );
 
 			// If we're on the blog home page, and we have no posts, say as much
@@ -433,7 +433,7 @@ o2.Routers.App = ( function( $, Backbone ) {
 			var firstWithReloginType = o2.Notifications.notifications.findFirst( 'relogin' );
 
 			if ( ! isLoggedIn ) {
-				o2.$appContainer.removeClass( 'current-user-' + o2.currentUser.nicename );
+				o2.$appContainer.removeClass( 'current-user-' + o2.currentUser.userNicename );
 
 				// If there is no relogin notification, add one
 				if ( 'undefined' === typeof firstWithReloginType ) {
@@ -447,7 +447,7 @@ o2.Routers.App = ( function( $, Backbone ) {
 					} );
 				}
 			} else {
-				o2.$appContainer.addClass( 'current-user-' + o2.currentUser.nicename );
+				o2.$appContainer.addClass( 'current-user-' + o2.currentUser.userNicename );
 
 				// Remove any relogin notifications
 				if ( 'undefined' !== typeof firstWithReloginType ) {

--- a/js/collections/users.js
+++ b/js/collections/users.js
@@ -35,9 +35,10 @@ o2.Collections.Users = ( function( $, Backbone ) {
 				if ( 'undefined' === typeof user ) {
 					// we don't have it, create an new one with some temporary values
 					user = new o2.Models.User( {
-						userLogin   : object.userLogin,
-						displayName : object.userLogin,
-						modelClass  : 'o2-incomplete-' + object.userLogin
+						userLogin    : object.userLogin,
+						userNicename : object.userNicename,
+						displayName  : object.userLogin,
+						modelClass   : 'o2-incomplete-' + object.userNicename
 					} );
 
 					// add it to the collection
@@ -116,7 +117,7 @@ o2.Collections.Users = ( function( $, Backbone ) {
 			var user = this.getUserFor( { userLogin: userLogin } );
 
 			// update img src's and a href's with .o2-incomplete-{userLogin}
-			var selectorClass = 'o2-incomplete-' + userLogin;
+			var selectorClass = 'o2-incomplete-' + user.userNicename;
 
 			$( 'a.' + selectorClass ).each( function() {
 				$( this ).attr( 'href', user.url ).removeClass( selectorClass );

--- a/js/models/user.js
+++ b/js/models/user.js
@@ -6,14 +6,15 @@ o2.Models.User = ( function( Backbone ) {
 	return Backbone.Model.extend( {
 		defaults: function() {
 			return {
-				userLogin   : '',
-				displayName : '',
-				url         : '',
-				urlTitle    : '',
-				hash        : '00000000000000000000000000000000',
-				modelClass  : '',
-				avatar      : '',
-				avatarSize  : 100
+				userLogin    : '',
+				displayName  : '',
+				userNicename : '',
+				url          : '',
+				urlTitle     : '',
+				hash         : '00000000000000000000000000000000',
+				modelClass   : '',
+				avatar       : '',
+				avatarSize   : 100
 			};
 		},
 


### PR DESCRIPTION
This fixes issue #16.

Users with e-mails as usernames would be unable to use o2-enabled sites
because jQuery selectors would get confused by the "." in their name and the site would break.

I've modified the plugin to use user nicenames for classes and selectors,
which should give class names and selections that won't break anything.

It seems like this may have been attempted before or regressed some time ago, because there were
some references in main.js to nicenames but nothing involving nicenames anywhere else. I've also fixed those to work correctly.