### PR TITLE
Allow up to 1-second difference in insert_comment_actions test.

### DIFF
--- a/tests/phpunit/test-o2-base.php
+++ b/tests/phpunit/test-o2-base.php
@@ -419,16 +419,19 @@ class o2BaseTest extends WP_UnitTestCase {
 
 	function test_insert_comment_actions() {
 
+		$right_now = date( 'U' );
 		$comment_id = wp_insert_comment( array(
 			'comment_content' => 'Test comment content'
 		) );
 
 		$o2_created_time = get_comment_meta( $comment_id, 'o2_comment_created', true );
 
-		$this->assertEquals(
-			current_time( 'timestamp', true ), $o2_created_time,
-			'Comments should get an o2 creation time meta when created'
-		);
+		//Allow 1 second max difference in case time has changed since the test started
+		$this->assertLessThanOrEqual(
+			1, $o2_created_time - $right_now,
+			'Comments should get a meta with a timestamp of when they were created upon creation'
+		); 
+
 	}
 
 	function test_has_approved_child() {


### PR DESCRIPTION
There was a race-condition in the insert_comment_actions test where
a test would fail if the second changed between the start and finish
of the test. (https://travis-ci.org/Automattic/o2/jobs/165872181)

I have modified the test to handle up to 1 full second of difference
in the checking. This should resolve that condition, and if the test
takes longer than a second something has gone horribly wrong somewhere
and we'd probably want to know that it takes over a second to insert
a comment anyways.