### PR TITLE
Unreplied Posts: Prevent a fatal error if main query isn't available yet

### DIFF
--- a/modules/unreplied-posts/load.php
+++ b/modules/unreplied-posts/load.php
@@ -34,7 +34,7 @@ class o2_Unreplied_Posts {
 	}
 
 	function pre_get_posts( $query ) {
-		if ( 'none' === get_query_var( 'replies' ) || ( !empty( $_GET['query_args']['replies'] ) && 'none' === $_GET['query_args']['replies'] ) ) {
+		if ( ( $query->is_main_query() && 'none' === get_query_var( 'replies' ) ) || ( !empty( $_GET['query_args']['replies'] ) && 'none' === $_GET['query_args']['replies'] ) ) {
 			// Manipulating WP_Query directly like this isn't great, but it works
 			$query->query_vars['ignore_sticky_posts'] = true;
 		}


### PR DESCRIPTION
`get_query_var()` requires that the global `$wp_query` is set up.

Fixes #120.