### PR TITLE
Add Alt+Shift+a as link keybinding

### DIFF
--- a/js/editor/editor.js
+++ b/js/editor/editor.js
@@ -35,6 +35,7 @@ o2Editor = {
 		$doc.on( 'drop',      '.o2-editor-wrapper', this.onDrop );
 
 		$doc.on( 'keydown', '.o2-editor-text', 'meta+shift+a', this.shortcutKey ); // Link, a la wp-admin
+		$doc.on( 'keydown', '.o2-editor-text', 'alt+shift+a',  this.shortcutKey ); // Link, a la wp-admin
 		$doc.on( 'keydown', '.o2-editor-text', 'ctrl+b',       this.shortcutKey ); // Bold (strong)
 		$doc.on( 'keydown', '.o2-editor-text', 'meta+b',       this.shortcutKey ); // Bold (strong)
 		$doc.on( 'keydown', '.o2-editor-text', 'ctrl+i',       this.shortcutKey ); // Italic (em)
@@ -402,7 +403,7 @@ o2Editor = {
 			e.preventDefault();
 			$( e.target ).parent().find( '.insert-media' ).click(); // cheap and dirty, but the handle to media gallery isn't otherwise clean
 			return;
-		} else if ( e.metaKey && e.shiftKey && 65 === e.which ) {
+		} else if ( ( e.metaKey || e.altKey ) && e.shiftKey && 65 === e.which ) {
 			tag = 'a';
 		} else if ( ( e.ctrlKey || e.metaKey ) && 66 === e.which ) {
 			tag = 'strong';

--- a/o2.php
+++ b/o2.php
@@ -406,7 +406,7 @@ class o2 {
 				'previewPlaceholder'                   => __( 'Generating preview...', 'o2' ),
 				'bold'                                 => __( 'Bold (ctrl/⌘-b)', 'o2' ),
 				'italics'                              => __( 'Italics (ctrl/⌘-i)', 'o2' ),
-				'link'                                 => __( 'Link (⌘-shift-a)', 'o2' ),
+				'link'                                 => __( 'Link (⌘/alt-shift-a)', 'o2' ),
 				'image'                                => __( 'Image', 'o2' ),
 				'blockquote'                           => __( 'Blockquote', 'o2' ),
 				'code'                                 => __( 'Code', 'o2' ),


### PR DESCRIPTION
The shortcut ⌘-shift-a to create links does not work reliably  on Firefox(and other browsers) on multiple platforms. This fixes #133 by adding a shortcut like Calypso.