### PR TITLE
Fixing o2.Utilities.phpToMoment to support escaping

### DIFF
--- a/js/utils/timestamp.js
+++ b/js/utils/timestamp.js
@@ -7,6 +7,12 @@ o2.Utilities.phpToMoment = function( s ) {
 	var m = '';
 	var lookBehind = '';
 	for ( var i = 0; i < s.length; i++ ) {
+		if ( lookBehind === "\\" ) { // Scaping character
+			m += '[' + s.charAt( i ) + ']';
+			lookBehind = s.charAt( i );
+			continue;
+		}
+
 		switch ( s.charAt( i ) ) {
 			case 'd': // Day of the month with leading zeroes
 				m += 'DD';
@@ -106,6 +112,7 @@ o2.Utilities.phpToMoment = function( s ) {
 			case 'u': // Microseconds
 			case 'I': // Daylight savings time
 			case 'Z': // Timezone offset in seconds
+			case '\\': // Scape character
 				break;
 
 			// Handle with lookBehind to handle 'jS'


### PR DESCRIPTION
[o2.Utilities.phpToMoment](https://github.com/Automattic/o2/blob/9a8be6b17fbfe4c4cb55ac88597020d89279057d/js/utils/timestamp.js#L6-L126) should support escape some chars like pt_BR and pt_PT dates.

For example, `j \d\e F \d\e Y` should return `D[ ][d][e][ ]MMMM[ ][d][e][ ]YYYY`.

Issue #135 