### PR TITLE
Add support to format the displayed time

### DIFF
--- a/modules/time-shortcode/js/time-shortcode.js
+++ b/modules/time-shortcode/js/time-shortcode.js
@@ -7,7 +7,7 @@
  * @param date - date object
  * @return string
  **/
-var o2_format_date = function( date ) {
+var o2_format_date = function( date, format ) {
 
 	var time_settings = o2_get_time_settings();
 
@@ -15,15 +15,32 @@ var o2_format_date = function( date ) {
 		return ( '00' + n ).slice( -2 );
 	};
 
-var timezone_offset = -date.getTimezoneOffset() / 60;
+	var timezone_offset = -date.getTimezoneOffset() / 60;
 	if( timezone_offset >= 0 ) {
 		timezone_offset = '+' + timezone_offset;
 	}
 
-	return time_settings.days[ date.getDay() ] + ', ' +
+	var full_date = time_settings.days[ date.getDay() ] + ', ' +
 		time_settings.months[ date.getMonth() ] + ' ' +
 		zero_prefix( date.getDate() ) + ', ' +
 		date.getFullYear() + ' ' +
 		zero_prefix( date.getHours() ) + ':' + zero_prefix( date.getMinutes() ) +
 		' UTC' + timezone_offset;
+
+	if ( typeof format === 'string' ) {
+		var p = full_date.indexOf( 'UTC' );
+		switch ( format ) {
+			case 'time':
+				return full_date.substr( p - 6 );
+
+			case 'date':
+				return full_date.substr( 0, p - 7 );
+
+			case 'shortdate':
+				var c = full_date.indexOf( ',' );
+				return full_date.substr( c + 2, p - c - 9 );
+		}
+	}
+
+	return full_date;
 };

--- a/modules/time-shortcode/load.php
+++ b/modules/time-shortcode/load.php
@@ -50,8 +50,10 @@ class o2_Time_Shortcode {
 			return $content;
 		}
 
+		$format = isset( $attr['format'] ) ? $attr['format'] : 'full';
+
 		// build the link and abbr microformat
-		$out = '<a href="http://www.timeanddate.com/worldclock/fixedtime.html?iso=' . gmdate( 'Ymd\THi', $time ) . '"><abbr class="globalized-date" title="' . gmdate( 'c', $time ) . '" data-time="' . absint( $time ) . '000">' . $content . '</abbr></a>';
+		$out = '<a href="http://www.timeanddate.com/worldclock/fixedtime.html?iso=' . gmdate( 'Ymd\THi', $time ) . '"><abbr class="globalized-date" title="' . gmdate( 'c', $time ) . '" data-time="' . absint( $time ) . '000" data-format="' . esc_attr( $format ) . '">' . $content . '</abbr></a>';
 
 		// add the time converter JS code if not already added
 		if ( ! has_action( 'wp_footer', array( 'o2_Time_Shortcode', 'time_conversion_script' ) ) ) {
@@ -152,7 +154,22 @@ class o2_Time_Shortcode {
 					}
 
 					var date = new Date( time );
-					$this.text( o2_format_date( date ) );
+					date = o2_format_date( date );
+
+					var format = $this.data( 'format' );
+					if ( format == 'time' ) {
+						var p = date.indexOf( 'UTC' );
+						$this.text( date.substr( p - 6 ) );
+					} else if ( format == 'date' ) {
+						var p = date.indexOf( 'UTC' );
+						$this.text( date.substr( 0, p - 6 ) );
+					} else if ( format == 'shortdate' ) {
+						var p = date.indexOf( 'UTC' );
+						var c = date.indexOf( ',' );
+						$this.text( date.substr( c + 2, p - c - 9 ) );
+					} else {
+						$this.text( date );
+					}
 
 				} );
 			} );

--- a/modules/time-shortcode/load.php
+++ b/modules/time-shortcode/load.php
@@ -153,23 +153,7 @@ class o2_Time_Shortcode {
 						return;
 					}
 
-					var date = new Date( time );
-					date = o2_format_date( date );
-
-					var format = $this.data( 'format' );
-					if ( format == 'time' ) {
-						var p = date.indexOf( 'UTC' );
-						$this.text( date.substr( p - 6 ) );
-					} else if ( format == 'date' ) {
-						var p = date.indexOf( 'UTC' );
-						$this.text( date.substr( 0, p - 6 ) );
-					} else if ( format == 'shortdate' ) {
-						var p = date.indexOf( 'UTC' );
-						var c = date.indexOf( ',' );
-						$this.text( date.substr( c + 2, p - c - 9 ) );
-					} else {
-						$this.text( date );
-					}
+					$this.text( o2_format_date( new Date( time ), $this.data( 'format' ) ) );
 
 				} );
 			} );

--- a/tests/qunit/modules/time-shortcode.js
+++ b/tests/qunit/modules/time-shortcode.js
@@ -2,7 +2,7 @@ QUnit.module( 'Time Shortcode' );
 
 //Set up the time settings function manually since PHP usually generates it
 var o2_get_time_settings = function(){
-	return { 
+	return {
 		"months": [
 				"January",
 				"February",
@@ -101,5 +101,25 @@ QUnit.test( "o2_format_date: valid, positive-offset date", function( assert ) {
 	assert.equal(
 		o2_format_date( date ), "Sunday, January 12, 2012 12:00 UTC+2",
 		"Correct date should return for positive UTC timezone"
+	);
+});
+
+QUnit.test( "o2_format_date: output formating", function( assert ) {
+
+	var date = new DateMock( 0, 12, 0, 2012, 12, 00, -120 ); // Sun, 12 Jan 2012 12:00 UTC+2
+
+	assert.equal(
+		o2_format_date( date, 'time' ), "12:00 UTC+2",
+		"Correct output for time format"
+	);
+
+	assert.equal(
+		o2_format_date( date, 'date' ), "Sunday, January 12, 2012",
+		"Correct output for date format"
+	);
+
+	assert.equal(
+		o2_format_date( date, 'shortdate' ), "January 12, 2012",
+		"Correct output for shortdate format"
 	);
 });


### PR DESCRIPTION
For more elaborate usages of the `[time]` shortcode I'd like to add an attribute format which can be

```
[time]Dec 18 15:00 UTC[/time] == [time format=full]Dec 18 15:00 UTC[/time]
→ Monday, December 18, 2017 16:00 UTC+1

[time format=time]Dec 18 15:00 UTC[/time]
→ 16:00 UTC+1

[time format=date]Dec 18 15:00 UTC[/time]
→ Monday, December 18, 2017

[time format=shortdate]Dec 18 15:00 UTC[/time]
→ December 18, 2017
```