### PR TITLE
add missing alt attribute to avatars

### DIFF
--- a/inc/tpl/comment-edit.php
+++ b/inc/tpl/comment-edit.php
@@ -1,6 +1,6 @@
 <header class="o2-comment-header comment">
 	<# if ( o2.options.showAvatars && data.author.avatar ) { #>
-	<img src="{{ data.author.avatar }}" width="{{ data.avatarSize }}" height="{{ data.avatarSize }}" class="avatar {{ data.author.modelClass }}" />
+	<img src="{{ data.author.avatar }}" alt="" width="{{ data.avatarSize }}" height="{{ data.avatarSize }}" class="avatar {{ data.author.modelClass }}" />
 	<# } #>
 	<div class="comment-meta commentmetadata">
 		<# if ( data.isAnonymousAuthor ) { #>

--- a/inc/tpl/comment.php
+++ b/inc/tpl/comment.php
@@ -8,7 +8,7 @@
 	<# } #>
 
 	<# if ( o2.options.showAvatars && data.author.avatar ) { #>
-	<img src="{{ data.author.avatar }}" width="{{ data.avatarSize }}" height="{{ data.avatarSize }}" class="avatar {{ data.author.modelClass }}" />
+	<img src="{{ data.author.avatar }}" alt="" width="{{ data.avatarSize }}" height="{{ data.avatarSize }}" class="avatar {{ data.author.modelClass }}" />
 	<# } #>
 	<div class="comment-meta commentmetadata o2-comment-metadata" data-o2-comment-id="{{ data.id }}">
 		<# if ( data.isAnonymousAuthor ) { #>

--- a/inc/tpl/logged-out-create-comment.php
+++ b/inc/tpl/logged-out-create-comment.php
@@ -1,6 +1,6 @@
 <header class="o2-comment-header comment">
 	<# if ( o2.options.showAvatars && data.author.avatar ) { #>
-	<img src="{{ data.author.avatar }}&amp;s={{ data.avatarSize }}" width="{{ data.avatarSize }}" height="{{ data.avatarSize }}" class="avatar" />
+	<img src="{{ data.author.avatar }}&amp;s={{ data.avatarSize }}" alt="" width="{{ data.avatarSize }}" height="{{ data.avatarSize }}" class="avatar" />
 	<# } #>
 </header>
 <div class="o2-editor o2-logged-out-editor">

--- a/inc/tpl/post-edit.php
+++ b/inc/tpl/post-edit.php
@@ -2,7 +2,7 @@
 	<div class="entry-meta">
 <# if ( ! data.isPage && o2.options.showAvatars && data.author.avatar ) { #>
 	<a href="{{ data.author.url }}" title="{{ data.author.urlTitle }}" class="author-avatar">
-		<img src="{{ data.author.avatar }}" width="{{ data.avatarSize }}" height="{{ data.avatarSize }}" class="avatar" />
+		<img src="{{ data.author.avatar }}" alt="" width="{{ data.avatarSize }}" height="{{ data.avatarSize }}" class="avatar" />
 	</a>
 <# } #>
 <# if ( ! data.isPage ) { #>

--- a/inc/tpl/post.php
+++ b/inc/tpl/post.php
@@ -2,7 +2,7 @@
 	<div class="entry-meta">
 	<# if ( ! data.isPage && o2.options.showAvatars && data.author.avatar ) { #>
 		<a href="{{ data.author.url }}" title="{{ data.author.urlTitle }}" class="author-avatar {{ data.author.modelClass }}">
-			<img src="{{ data.author.avatar }}" width="{{ data.author.avatarSize }}" height="{{ data.author.avatarSize }}" class="avatar {{ data.author.modelClass }}" />
+			<img src="{{ data.author.avatar }}" alt="" width="{{ data.author.avatarSize }}" height="{{ data.author.avatarSize }}" class="avatar {{ data.author.modelClass }}" />
 		</a>
 	<# } #>
 	<# if ( ! data.isPage ) { #>

--- a/modules/live-comments/load.php
+++ b/modules/live-comments/load.php
@@ -34,7 +34,7 @@ class o2_Live_Comments_Widget extends WP_Widget {
 			</script>
 			<script type="html/template" id='tmpl-o2-live-item-template'>
 				<# if ( o2.options.showAvatars && data.author.avatar ) { #>
-				<img src="{{ data.author.avatar }}" width="{{ data.author.avatarSize }}" height="{{ data.author.avatarSize }}" class="avatar o2-live-item-img {{ data.author.modelClass }}" />
+				<img src="{{ data.author.avatar }}" alt="" width="{{ data.author.avatarSize }}" height="{{ data.author.avatarSize }}" class="avatar o2-live-item-img {{ data.author.modelClass }}" />
 				<# } #>
 				<p class="o2-live-item-text"><a href="{{ data.permalink }}" data-domref="{{ data.domRef }}"
 					<# if ( 'comment' === data.type ) { #>

--- a/modules/notifications/load.php
+++ b/modules/notifications/load.php
@@ -48,7 +48,7 @@ class o2_Notifications extends o2_API_Base {
 		<script type="html/template" id="tmpl-o2-notification">
 
 		<# if ( '' !== data.iconUrl ) { #>
-			<img src="{{ data.iconUrl }}&amp;s={{ data.iconSize }}" width="{{ data.iconSize }}" height="{{ data.iconSize }}" class="avatar {{data.iconClass}}" />
+			<img src="{{ data.iconUrl }}&amp;s={{ data.iconSize }}" alt="" width="{{ data.iconSize }}" height="{{ data.iconSize }}" class="avatar {{data.iconClass}}" />
 		<# } #>
 
 		<# if ( data.dismissable ) { #>


### PR DESCRIPTION
Hi, 
cc @ocean90,

**Even empty**, `alt` attribute should always be set to avoid assistive technologies to vocalize the file name. I guess we do not need to put author's name since it's always displayed close to the avatar. We do not need to use alt texts like "avatar" because this provide no information for the user of AT.

See Andrea's issue opened in meta.trac.w.org here: https://meta.trac.wordpress.org/ticket/3371

This patch was tested on a local instance of o2. Seems to fix the issue.

Cheers,
Jb