### PR TITLE
Fix process_tags overwriting existing tags

### DIFF
--- a/inc/tags.php
+++ b/inc/tags.php
@@ -336,7 +336,7 @@ class o2_Tags extends o2_Terms_In_Comments {
 
 		$tags = $this->gather_all_tags( $post );
 
-		wp_set_post_tags( $post->ID, $tags, false );
+		wp_set_post_tags( $post->ID, $tags, true );
 	}
 
 	function gather_all_tags( $post ) {


### PR DESCRIPTION
Currently when one tries to add tags to a post by hooking into the `o2_create_post` the tags are overwritten by `process_tags` which overwrites any existing tags. 