### PR TITLE
X-post: ignore non-post post types.

### DIFF
--- a/inc/xposts.php
+++ b/inc/xposts.php
@@ -334,6 +334,10 @@ class o2_Xposts extends o2_Terms_In_Comments {
 		if ( 'publish' != $new )
 			return;
 
+		if ( 'post' !== $post->post_type ) {
+			return;
+		}
+
 		$subdomains = $this->find_xposts( $post->post_content );
 		if ( ! $subdomains )
 			return;


### PR DESCRIPTION
In testing a bug on WordPress.com we noticed that non-post post types can trigger an x-post. Probably best to ignore these.

In this specific use case, 'safecss' and 'customize_changeset' post types are triggered when updating the Custom CSS content on a WordPress.com site (the CSS revision is stored as a custom post type).

This change simply ignores non-post post types.