### PR TITLE
CheckList: strip tags from data stored in item-text attribute

### DIFF
--- a/inc/fragment.php
+++ b/inc/fragment.php
@@ -728,15 +728,23 @@ class o2_Fragment {
 		// processing between brackets because it messes up not-yet-filtered shortcodes that have url
 		// attributes like googlemaps
 
-		$pieces = preg_split( '/(\[[^\]]*])/i', $content, -1, PREG_SPLIT_NO_EMPTY | PREG_SPLIT_DELIM_CAPTURE );
+		$regex = '/(\[[^\]]*])/i';
 
-		$content = '';
+		$placeholders = $matches = array();
+		$count = 0;
 
-		foreach( (array) $pieces as $piece ) {
-			if ( '[' !== substr( $piece, 0, 1 ) ) {
-				$piece = make_clickable( $piece );
-			}
-			$content .= $piece;
+		while ( preg_match( $regex, $content, $matches ) ) {
+			$placeholder = ":: o2-make-clickable-placeholder $count ::";
+			$placeholders[ $count ] = $matches[0];
+			$content = preg_replace( $regex, $placeholder, $content, 1 );
+			$count++;
+		}
+
+		$content = make_clickable( $content );
+
+		foreach ( $placeholders as $count => $original ) {
+			$placeholder = ":: o2-make-clickable-placeholder $count ::";
+			$content = str_replace( $placeholder, $original, $content );
 		}
 
 		return $content;


### PR DESCRIPTION
The data attribute `data-item-text` tries to store the content of the
checklist item, but if the content contains html, then the result is that
malformed html is generated.

This strips the tags from the html before encoding it in the data
attribute.

Before:
![before-fix](https://user-images.githubusercontent.com/2036909/40379082-3ab7cbf0-5dc3-11e8-8ebc-dc0f0191a720.png)

After:
![after-fix](https://user-images.githubusercontent.com/2036909/40379088-403a3dec-5dc3-11e8-8bb9-c901e3927660.png)


Fixes #123 

It appears that the reason for storing the content is to allow it to be used [when editing](https://github.com/Automattic/o2/blob/81f7ed8672e197174a8f91f475c18084fb3d968b/modules/checklists/js/views/common.js#L134) the checklist item. I suppose this change might break that flow, since it would erase the html, but that probably needs to be refactored to work differently for safe manipulation of html and I think this bug fix is more important than preserving that behavior.