### PR TITLE
Fix Tag Processing for Posts Updated via the REST API

### DIFF
--- a/inc/tags.php
+++ b/inc/tags.php
@@ -388,7 +388,7 @@ class o2_Tags extends o2_Terms_In_Comments {
 		// If we're doing any other kind of write, respect the
 		// tags that have already been saved during the form
 		// submission, API request, etc.
-		$current_tags = o2_Fragment::get_post_tags( $post->ID );
+		$current_tags = wp_get_post_tags( $post->ID );
 		foreach ( $current_tags as $current_tag ) {
 			$tags[] = $current_tag->slug;
 		}


### PR DESCRIPTION
o2 would like there to be only one source of and storage for tags: the post and comments' contents via #inline-tags.

To integrate with the rest of the world, though, o2 currently tries to accommodate tags submitted via wp-admin/ (Classic Editor, Quick Edit, and the Bulk Post Editor) by checking for various `$_POST` and `$_GET` keys.

These limited checks, however, mean that o2 does not currently accommodate tags submitted through REST API requests; these tags get overwritten by o2's tag processing.

Instead of looking for wp-admin/ requests and handling them specially, let's flip the logic around and handle o2 write requests specially:

* For o2 write requests, overwrite any existing tags with those found in #inline-tags.
* For any other requests, append the #inline-tags to the existing set of tags.

The "is this an o2 write request" check is slightly fragile.

Fixes #161

To test: For each of:
* o2 editor,
* wp-admin/ Classic editor,
* Gutenberg,
* wp-admin/ quick edit, and
* wp-admin bulk edit,
1. Add a post tag,
2. See that it really got added (refresh the page),
3. Remove that post tag,
4. See that it really got removed (refresh thee page).

(Note that the bulk editor can add tags but not remove them.)