### PR TITLE
Move the template of the live item into the inc/tpl folder

### DIFF
--- a/inc/templates.php
+++ b/inc/templates.php
@@ -18,7 +18,8 @@ class o2_Templates {
 			'comment-edit',
 			'logged-out-create-comment',
 			'xpost',
-			'search-form'
+			'search-form',
+			'live-item-template',
 		) );
 		$this->template_dir = plugin_dir_path( __FILE__ ) . 'tpl/';
 

--- a/inc/tpl/live-item-template.php
+++ b/inc/tpl/live-item-template.php
@@ -1,0 +1,17 @@
+<# if ( o2.options.showAvatars && data.author.avatar ) { #>
+	<img src="{{ data.author.avatar }}" alt="" width="{{ data.author.avatarSize }}" height="{{ data.author.avatarSize }}" class="avatar o2-live-item-img {{ data.author.modelClass }}" />
+<# } #>
+<p class="o2-live-item-text"><a href="{{ data.permalink }}" data-domref="{{ data.domRef }}"
+	<# if ( 'comment' === data.type ) { #>
+		data-postid="{{ data.postID }}"
+	<# } #>
+	>{{{ data.title }}}</a>
+	<br/>
+	<span class="entry-date o2-timestamp" data-unixtime="{{ data.unixtime }}" data-domref="{{ data.domRef }}"
+		<# if ( 'comment' === data.type ) { #>
+			data-postid="{{ data.postID }}"
+		<# } #>
+	>
+	</span>
+</p>
+<div class="o2-live-item-clear"></div>

--- a/modules/live-comments/load.php
+++ b/modules/live-comments/load.php
@@ -32,27 +32,8 @@ class o2_Live_Comments_Widget extends WP_Widget {
 			<script type="html/template" id='tmpl-o2-live-untitled-comment-title-template'>
 				<?php echo esc_html( $untitled_comment_title ); ?>
 			</script>
-			<script type="html/template" id='tmpl-o2-live-item-template'>
-				<# if ( o2.options.showAvatars && data.author.avatar ) { #>
-				<img src="{{ data.author.avatar }}" alt="" width="{{ data.author.avatarSize }}" height="{{ data.author.avatarSize }}" class="avatar o2-live-item-img {{ data.author.modelClass }}" />
-				<# } #>
-				<p class="o2-live-item-text"><a href="{{ data.permalink }}" data-domref="{{ data.domRef }}"
-					<# if ( 'comment' === data.type ) { #>
-						data-postid="{{ data.postID }}"
-					<# } #>
-					>{{{ data.title }}}</a>
-					<br/>
-					<span class="entry-date o2-timestamp" data-unixtime="{{ data.unixtime }}" data-domref="{{ data.domRef }}"
-						<# if ( 'comment' === data.type ) { #>
-							data-postid="{{ data.postID }}"
-						<# } #>
-					>
-					</span>
-				</p>
-				<div class="o2-live-item-clear">
-				</div>
-			</script>
 		<?php
+		// The content of the widget is diplayed using the `/inc/tpl/live-item-template.php` template.
 	}
 
 	function register_widget_scripts() {


### PR DESCRIPTION
Hi,

First, I'd like to congratulate the plugin contributors for the great work they achieved.

The template of the "live comments" module unlike the others is not overridable which is a bit annoying when you want to replace the gravatars with a local avatar using template overrides.

I imagine this was decided to avoid loading the template if the widget is not active, but I feel the extra load is better than the lack of customization possibility.

If you think it's absolutely required to make sure the widget is active before loading the template, I can edit this PR.

Thanks in advance for your time.