### PR TITLE
Enable first line title parsing for Firefox

### DIFF
--- a/js/editor/editor.js
+++ b/js/editor/editor.js
@@ -721,10 +721,7 @@ o2Editor = {
 
 	firstLineIsProbablyATitle: function( text ) {
 		// Firefox isn't doesn't obey ::first-line in textareas,
-		// so let's disable auto title.
-		if ( o2Editor.isFirefox ) {
-			return false;
-		}
+		// This is not true. https://caniuse.com/#feat=css-first-line
 
 		var lines = text.split('\n');
 		if ( ! lines || 1 === lines.length && '' === lines[0] ) {

--- a/js/views/new-post.js
+++ b/js/views/new-post.js
@@ -106,7 +106,7 @@ o2.Views.FrontSidePost = ( function( $ ) {
 				titleFiltered: titleRaw,
 				contentFiltered: contentFiltered,
 				isFollowing: isFollowing,
-				disableAutoTitle: o2Editor.isFirefox, // Force auto-title off in Firefox
+				disableAutoTitle: false,
 				postFormat: this.options.viewFormat // retrieve from the view
 			} );
 			o2.App.posts.add( clientModel ); // @todo we've made the view coupled to the app here - could we use an event?


### PR DESCRIPTION
This PR removes the check for Firefox that disables first line title parsing.
The reasoning of not supporting ::first-line is no longer valid. 
https://caniuse.com/#feat=css-first-line

Test:

1. Apply PR
2. Add new post with a suitable first line title
3. Confirm title is added as an H1 to the post, and set in wp-admin