### PR TITLE
Remove continue, throws warning in latest PHP and equivalent to break

### DIFF
--- a/o2.php
+++ b/o2.php
@@ -617,8 +617,6 @@ class o2 {
 						break;
 
 					default:
-						continue;
-
 						break;
 				}
 			}


### PR DESCRIPTION

The title says it all, removes the `continue;` from within the switch.
Using a continue there is equivalent to break, and latest PHP is issuing a warning.