### PR TITLE
Use the user_nicename instead of the user_login

### DIFF
--- a/modules/checklists/load.php
+++ b/modules/checklists/load.php
@@ -475,7 +475,7 @@ class o2_List_Creator {
 
 		$current_user = wp_get_current_user();
 		if ( $current_user instanceof WP_User ) {
-			$current_user_mention = " (@" . $current_user->user_login . ")";
+			$current_user_mention = " (@" . $current_user->user_nicename . ")";
 		}
 
 		return $current_user_mention;


### PR DESCRIPTION
As the user_nicename is the value used when writing author URLs, it is best to use it. Morevover it is more secured than using the user_login.