### PR TITLE
Don't add JSON data to content if o2_process_the_content is false

### DIFF
--- a/o2.php
+++ b/o2.php
@@ -887,6 +887,10 @@ class o2 {
 		if ( ! is_page() && ! empty( $post->post_password ) ) {
 			return $content;
 		}
+		
+		if ( ! apply_filters( 'o2_process_the_content', true ) ) {
+			return $content;
+		}
 
 		$conversation = array();
 		if ( is_single() || is_category() || is_archive() || is_author() || is_home() || is_page() || is_search() ) {


### PR DESCRIPTION
Currently, when a shortcode is using a nested `the_content` filter, the JSON data is added to that content. An example can be seen on https://make.wordpress.org/polyglots/handbook/tools/poedit/

<img width="500" src="https://user-images.githubusercontent.com/617637/81503090-086f5680-92e2-11ea-9bf5-202c934d659c.png"/>

Code of the shortcode: https://meta.trac.wordpress.org/browser/sites/trunk/wordpress.org/public_html/wp-content/plugins/handbook/inc/callout-boxes.php?rev=5465&marks=141-144#L141