### PR TITLE
Jetpack compatibility: Update is_tablet() to use public method

### DIFF
--- a/o2.php
+++ b/o2.php
@@ -9,6 +9,8 @@ Author URI: http://wordpress.com/
 License: GNU General Public License v2 or later
 */
 
+use \Automattic\Jetpack\Device_Detection\User_Agent_Info;
+
 /*  Copyright 2013 Automattic
 
 	This program is free software; you can redistribute it and/or modify
@@ -1161,7 +1163,13 @@ class o2 {
 	 * Returns true if the user agent is recognized as a tablet
 	 */
 	public static function is_tablet() {
-		$is_tablet = ( class_exists( 'Jetpack_User_Agent_Info' ) ) ? ( new Jetpack_User_Agent_Info )->is_tablet() : false;
+		if ( class_exists( '\Automattic\Jetpack\Device_Detection\User_Agent_Info' ) ) {
+			$is_tablet = ( new User_Agent_Info )->is_tablet();
+		} else if ( class_exists( 'Jetpack_User_Agent_Info' ) ) {
+			$is_tablet = Jetpack_User_Agent_Info::is_tablet();
+		} else {
+			$is_tablet = false;
+		}
 		return $is_tablet;
 	}
 

--- a/o2.php
+++ b/o2.php
@@ -1164,7 +1164,8 @@ class o2 {
 	 */
 	public static function is_tablet() {
 		if ( class_exists( '\Automattic\Jetpack\Device_Detection\User_Agent_Info' ) ) {
-			$is_tablet = ( new User_Agent_Info )->is_tablet();
+			$jetpack_user_agent = new User_Agent_Info();
+			$is_tablet = $jetpack_user_agent->is_tablet();
 		} else if ( class_exists( 'Jetpack_User_Agent_Info' ) ) {
 			$is_tablet = Jetpack_User_Agent_Info::is_tablet();
 		} else {

--- a/o2.php
+++ b/o2.php
@@ -1161,7 +1161,7 @@ class o2 {
 	 * Returns true if the user agent is recognized as a tablet
 	 */
 	public static function is_tablet() {
-		$is_tablet = ( class_exists( 'Jetpack_User_Agent_Info' ) ) ? Jetpack_User_Agent_Info::is_tablet() : false;
+		$is_tablet = ( class_exists( 'Jetpack_User_Agent_Info' ) ) ? ( new Jetpack_User_Agent_Info )->is_tablet() : false;
 		return $is_tablet;
 	}
 


### PR DESCRIPTION
Jetpack_User_Agent_Info's is_tablet() method is no longer static as of Jetpack 8.7. Introduced in [this change](https://github.com/Automattic/jetpack/pull/16129/files#r451102718). 

As of Jetpack 8.7, this will actually fatal sites running Jetpack 8.7. 

We have a [PR](https://github.com/Automattic/jetpack/pull/16430) which patches this on the Jetpack side, but it should be updated here as well. 

This PR works in both versions of the method. 
