### PR TITLE
Update `data-actionstate` on buttons

### DIFF
--- a/js/utils/post-action-states.js
+++ b/js/utils/post-action-states.js
@@ -63,6 +63,7 @@ o2.PostActionStates = ( function( $ ) {
 				}
 
 				target.data( 'actionstate', newState );
+				target.attr( 'data-actionstate', newState );
 				target.attr( 'title', newStateData.title ); // TODO only on <a>s?
 				target.text( newStateData.shortText );
 			}


### PR DESCRIPTION
Stateful buttons using the `PostActionStates` system have a `data-actionstate` attribute on them in the DOM. There was a bug (omission?) that prevented this attribute from being updated dynamically, so once changed the value would be wrong until page reload. This is not ideal for theme CSS that relies on this attribute to determine state.

This omission is possibly due to a gotcha in [jQuery `.data()`](https://api.jquery.com/data/), where it doesn't do anything about `data-*` attributes:

> Using the `data()` method to update data does not affect attributes in the DOM. To set a `data-*` attribute value, use `attr`.

I think we can keep the original `data()` call for now because some parts of the code still rely on that being there. (Maybe we should migrate everything to `.attr( 'data-*' )` but that would require more extensive testing which I don't have the appetite to do right now.)

## Affected buttons

- To-do
- Stick post to home
- Follow comments

[(relevant code)](https://github.com/Automattic/o2/search?q=o2.PostActionStates.setState&type=Code)