### PR TITLE
Support jQuery 3.5 introduced in WP 5.6

### DIFF
--- a/modules/offline/js/offline.js
+++ b/modules/offline/js/offline.js
@@ -28,7 +28,7 @@ o2.Offline = {
 			o2.Offline.onWindowUnloading();
 		} );
 
-		jQuery( window ).unload( function() {
+		jQuery( window ).on( 'unload', function() {
 			o2.Offline.onWindowUnloading();
 		} );
 	},


### PR DESCRIPTION
`unload()` has been deprecated since jQuery 1.8 and has been removed in 3.0. 
https://api.jquery.com/unload/

WordPress 5.6 has now updated to jQuery 3.5. Thus causing "Uncaught TypeError: jQuery(...).unload is not a function"