### PR TITLE
Move preview capability checks into the specific preview handlers.

### DIFF
--- a/inc/read-api.php
+++ b/inc/read-api.php
@@ -461,20 +461,25 @@ class o2_Read_API extends o2_API_Base {
 	public static function preview() {
 		$response = '<p>' . __( 'Nothing to preview.', 'o2' ) . '</p>';
 
-		// Only users that can edit posts should be able to see the preview
-		if ( ! current_user_can( 'edit_posts' ) ) {
-			self::die_failure( 'cannot_edit_posts', __( 'Sorry, you are not allowed to edit posts on this site.', 'o2' ) );
-		}
-
 		if ( ! empty( $_REQUEST['data'] ) ) {
 			switch ( $_REQUEST['type'] ) {
 				case 'comment':
+					// Reserve Comment previews for logged in users if required.
+					if ( get_option( 'comment_registration' ) && ! is_user_logged_in() ) {
+						self::die_failure( 'cannot_comment', __( 'Sorry, you are not allowed to comment on this site.', 'o2' ) );
+					}
+
 					$response = apply_filters( 'o2_preview_comment', wp_unslash( $_REQUEST['data'] ) );
 					$response = wp_unslash( apply_filters( 'pre_comment_content', $response ) );
 					$response = trim( apply_filters( 'comment_text', $response ) );
 
 					break;
 				case 'post':
+					// Only users that can edit posts should be able to see the preview
+					if ( ! current_user_can( 'edit_posts' ) ) {
+						self::die_failure( 'cannot_edit_posts', __( 'Sorry, you are not allowed to edit posts on this site.', 'o2' ) );
+					}
+
 					$message = new stdClass;
 					$message->titleRaw = '';
 					$message->contentRaw = wp_unslash( $_REQUEST['data'] );


### PR DESCRIPTION
This moves the capability checks for comment previewing away from `edit_posts`. These were added in #205.

Example: Attempt to preview a comment on make.wordpress.org/meta/ from a user who is not a member of the site (or cannot edit posts).

This requires a security review of some form, I believe it should be safe, but needs to be reviewed to ensure that the same comment_text-sanitization that occurs on comment post is applied here during preview.
For example, posting `<script>alert(1)</script>` should not work in the preview.

See #215