### PR TITLE
Support PHP Escaped characters

### DIFF
--- a/js/utils/timestamp.js
+++ b/js/utils/timestamp.js
@@ -7,6 +7,11 @@ o2.Utilities.phpToMoment = function( s ) {
 	var m = '';
 	var lookBehind = '';
 	for ( var i = 0; i < s.length; i++ ) {
+		// Handle PHP escaping
+		if ( '\\' === lookBehind ) {
+			m += '[' + s.charAt( i ) + ']';
+		}
+
 		switch ( s.charAt( i ) ) {
 			case 'd': // Day of the month with leading zeroes
 				m += 'DD';
@@ -110,6 +115,10 @@ o2.Utilities.phpToMoment = function( s ) {
 
 			// Handle with lookBehind to handle 'jS'
 			case 'j': // Day of the month without leading zeroes
+				break;
+
+			// Handle PHP escaping
+			case '\\':
 				break;
 
 			default:

--- a/js/utils/timestamp.js
+++ b/js/utils/timestamp.js
@@ -7,11 +7,6 @@ o2.Utilities.phpToMoment = function( s ) {
 	var m = '';
 	var lookBehind = '';
 	for ( var i = 0; i < s.length; i++ ) {
-		// Handle PHP escaping
-		if ( '\\' === lookBehind ) {
-			m += '[' + s.charAt( i ) + ']';
-		}
-
 		switch ( s.charAt( i ) ) {
 			case 'd': // Day of the month with leading zeroes
 				m += 'DD';
@@ -119,6 +114,7 @@ o2.Utilities.phpToMoment = function( s ) {
 
 			// Handle PHP escaping
 			case '\\':
+				m += '[' + s.charAt( ++i ) + ']';
 				break;
 
 			default:


### PR DESCRIPTION
Fixes #226 

With the date_format being set to `j \d\e F \d\e Y`...

| | Before | After |
| --- | --- | --- |
| UI | <img width="289" alt="Screenshot 2023-06-16 at 12 45 42 pm" src="https://github.com/Automattic/o2/assets/767313/9c309b37-4a09-423d-9d0c-c18bb03696c6"> | <img width="195" alt="Screenshot 2023-06-16 at 12 55 20 pm" src="https://github.com/Automattic/o2/assets/767313/b608d75d-1345-4f63-96eb-7a2d6f9c0b10"> |
| Moment.JS string | `D[ ][\]DD[\]Z[ ]MMMM[ ][\]DD[\]Z[ ]YYYY` | `D[ ][d][e][ ]MMMM[ ][d][e][ ]YYYY` |
