### PR TITLE
Notifications: Don't load if not loaded

### DIFF
--- a/modules/notifications/js/app/notifications.js
+++ b/modules/notifications/js/app/notifications.js
@@ -77,5 +77,7 @@ jQuery( document ).on( 'preload.o2', function( bootstrap ) {
 } );
 
 jQuery( document ).on( 'ready.o2', function() {
-	o2.Notifications.open();
+	if ( 'undefined' !== typeof o2.Notifications ) {
+		o2.Notifications.open();
+	}
 } );

--- a/modules/notifications/js/app/notifications.js
+++ b/modules/notifications/js/app/notifications.js
@@ -77,7 +77,5 @@ jQuery( document ).on( 'preload.o2', function( bootstrap ) {
 } );
 
 jQuery( document ).on( 'ready.o2', function() {
-	if ( 'undefined' !== typeof o2.Notifications ) {
-		o2.Notifications.open();
-	}
+	o2.Notifications?.open();
 } );


### PR DESCRIPTION
I don't really know why this happens, but `ready.o2` fires after `preload.o2`, but the `ready.o2` hook is fired before the `preload.o2` hook has run too.

I assume this is because o2 is assuming that `ready.o2` is unique to o2, but actually it's just a namespaced variant of `ready`, so document ready triggers it, and then o2 triggers it.

```
15:20:23.374 notifications.js?ver=6.5-beta2-57697:81 ready.o2 without notifs
15:20:23.403 notifications.js?ver=6.5-beta2-57697:76 preload.o2
15:20:23.432 notifications.js?ver=6.5-beta2-57697:81 ready.o2 with notifs
```

Fixes #225