### PR TITLE
Leaving enought height for the new like widget

### DIFF
--- a/modules/post-actions/css/_post-actions.scss
+++ b/modules/post-actions/css/_post-actions.scss
@@ -412,7 +412,7 @@ nav.o2-post-footer-actions {
 
 			color: $gray-60;
 
-			padding: 3px;
+			padding: 7px 5px 5px;
 			padding-right: 10px;
 
 			margin: 0;

--- a/modules/post-actions/css/style-rtl.css
+++ b/modules/post-actions/css/style-rtl.css
@@ -398,7 +398,7 @@ nav.o2-post-footer-actions ul li > a, nav.o2-post-footer-actions ul li > span > 
   text-align: right;
   text-decoration: none;
   color: #666666;
-  padding: 3px;
+  padding: 7px 5px 5px;
   padding-left: 10px;
   margin: 0;
   line-height: 1.5;
@@ -649,7 +649,7 @@ nav.o2-post-footer-actions .o2-follow.post-comments-subscribed:hover:after {
 .o2-post div.jetpack-likes-widget-wrapper {
   min-height: 0;
   line-height: 0;
-  height: 27px;
+  height: 32px;
   width: auto;
   overflow: hidden;
   -webkit-overflow-scrolling: none;
@@ -660,6 +660,7 @@ nav.o2-post-footer-actions .o2-follow.post-comments-subscribed:hover:after {
   display: inline-block;
 }
 /* line 107, style.scss */
+.o2-post .o2-post-footer-action-row,
 .o2-post .o2-post-footer-action-likes {
   padding-top: 7px;
 }

--- a/modules/post-actions/css/style.css
+++ b/modules/post-actions/css/style.css
@@ -345,7 +345,7 @@ nav.o2-post-footer-actions {
       text-align: left;
       text-decoration: none;
       color: #666;
-      padding: 3px;
+      padding: 7px 5px 5px;
       padding-right: 10px;
       margin: 0;
       line-height: 1.5;
@@ -519,13 +519,14 @@ nav.o2-post-footer-actions .o2-follow.post-comments-subscribed:hover:after {
 .o2-post div.jetpack-likes-widget-wrapper {
   min-height: 0;
   line-height: 0;
-  height: 27px;
+  height: 32px;
   width: auto;
   overflow: hidden;
   -webkit-overflow-scrolling: none; }
 .o2-post .post-likes-widget-placeholder .loading {
   padding-top: 12px;
   display: inline-block; }
+.o2-post .o2-post-footer-action-row,
 .o2-post .o2-post-footer-action-likes {
   padding-top: 7px; }
 

--- a/modules/post-actions/css/style.scss
+++ b/modules/post-actions/css/style.scss
@@ -91,7 +91,7 @@ nav.o2-post-footer-actions {
 	div.jetpack-likes-widget-wrapper {
 		min-height: 0;
 		line-height: 0;
-		height: 27px;
+		height: 32px;
 		width: auto;
 		// We need the overflow and -webkit-overflow-scrolling styles on the
 		// iframe wrapper in order to avoid touch drag scrolling the likes iframe
@@ -104,6 +104,7 @@ nav.o2-post-footer-actions {
 		display: inline-block;
 	}
 
+	.o2-post-footer-action-row,
 	.o2-post-footer-action-likes {
 		padding-top: 7px;
 	}


### PR DESCRIPTION
The new like widget is higher than the actions row used in the O2 Plugin.
This Patch leaves enough space for the new widget to fit without being cut. It also makes the height of the reply button match the size of the like button in the widget.

Before:
<img width="1211" alt="Screenshot 2024-03-12 at 19 10 05" src="https://github.com/Automattic/o2/assets/3832570/8401e6b2-d546-4efe-a560-0d9960b327e2">

After:
<img width="1192" alt="Screenshot 2024-03-12 at 19 58 28" src="https://github.com/Automattic/o2/assets/3832570/c531e438-c549-48bb-9441-b331f8786d4e">
