### PR TITLE
Todo module: Avoid PHP Warnings

### DIFF
--- a/modules/to-do/load.php
+++ b/modules/to-do/load.php
@@ -488,7 +488,7 @@ class o2_ToDos extends o2_API_Base {
 	function request( $qvs ) {
 		if ( !empty( $_GET['tags'] ) || !empty( $_GET['post_tag'] ) ) {
 			$filter_tags = ( !empty( $_GET['tags'] ) ) ? $_GET['tags'] : $_GET['post_tag'];
-			$filter_tags = (array)explode( ',', $filter_tags );
+			$filter_tags = (array) wp_parse_list( $filter_tags );
 	 		foreach( (array)$filter_tags as $filter_tag ) {
 	 			$filter_tag = sanitize_key( $filter_tag );
 	 			$new_tax_query = array(


### PR DESCRIPTION
Use `wp_parse_list()` to handle array-like inputs, to avoid PHP Warnings.

```
E_WARNING: explode() expects parameter 2 to be string, array given
```

Upstreaming this change that I made to the WordPress.org version of o2 back on 2024-04-24.

Looks like this was triggered by something like this:
```
GET https://example.org/p2/2024/04/24/post-name-here/?tags[]=junk
```