### PR TITLE
Add comments id attribute

### DIFF
--- a/inc/tpl/post-view.php
+++ b/inc/tpl/post-view.php
@@ -1,5 +1,5 @@
 <div class="o2-post"></div>
-<div class="o2-post-comments"></div>
+<div class="o2-post-comments" id="comments"></div>
 <div class="o2-post-comment-controls"></div>
 
 <# if ( data.showNavigation ) { #>


### PR DESCRIPTION
Allows use of URL fragment `#comments`, as discussed in https://meta.trac.wordpress.org/ticket/4403.

Resolves #170.
