### PR TITLE
Avoid PHP Warnings when `the_content` filters are run without a $post context.

### DIFF
--- a/modules/post-actions/load.php
+++ b/modules/post-actions/load.php
@@ -91,7 +91,8 @@ class o2_Post_Actions {
 			return $content;
 		}
 
-		$actions = apply_filters( 'o2_filter_post_actions', array(), $post->ID );
+		$post_id = ! empty( $post->ID ) ? $post->ID : 0;
+		$actions = apply_filters( 'o2_filter_post_actions', array(), $post_id );
 
 		$content .= "<nav class='o2-post-footer-actions'>";
 
@@ -123,7 +124,8 @@ class o2_Post_Actions {
 			return $content;
 		}
 
-		$actions = apply_filters( 'o2_filter_post_actions', array(), $post->ID );
+		$post_id = ! empty( $post->ID ) ? $post->ID : 0;
+		$actions = apply_filters( 'o2_filter_post_actions', array(), $post_id );
 
 		$content .= "</div>";
 		$content .= "<ul class='o2-post-footer-action-row'>";


### PR DESCRIPTION
Fixes issues like this:

> PHP Warning: Attempt to read property "ID" on null
> Source: wp-cron.php
> Cron Task: jp_sitemap_cron_hook