### PR TITLE
Avoid processing the_content when o2_process_the_content is false

### DIFF
--- a/o2.php
+++ b/o2.php
@@ -891,6 +891,10 @@ class o2 {
 			return $content;
 		}
 
+		if ( ! apply_filters( 'o2_process_the_content', true ) ) {
+			return $content;
+		}
+
 		// password protected post? return immediately (password protected pages are OK)
 		if ( ! is_page() && ! empty( $post->post_password ) ) {
 			return $content;


### PR DESCRIPTION
This method isn't using the `o2_process_the_content` filter which can cause a significant speed issue when the content filters are being run in a context that doesn't require the metadata - such as within a shortcode output in the middle of the page.

On URLs such as this:
https://make.wordpress.org/docs/handbook/documentation-team-handbook/tone-and-voice-guide/
Where all of the notice blocks are shortcodes that render `the_content` within you'd end up with many duplicate o2 `<script>`'s which then caused shortcode parsing to timeout.

With this change, the page load time of the above page goes from 100+ seconds to <1s when xDebug is enabled, and from 0.6-0.7s to ~0.4 in production.