### PR TITLE
Validate read API query vars and withhold trashed post content

### DIFF
--- a/inc/fragment.php
+++ b/inc/fragment.php
@@ -36,6 +36,20 @@ class o2_Fragment {
 	 */
 	public static function get_fragment_from_post( $my_post, $args = array() ) {
 
+		// Trashed posts reach this unauthenticated poll; anyone who cannot edit one
+		// gets its ID and nothing else. Must stay the first statement in this function:
+		// the filter swaps below are restored further down. unixtime is required by the
+		// poll's o2_date_sort comparator, and is deliberately 0 rather than the real value.
+		if ( 'trash' === get_post_status( $my_post->ID ) && ! current_user_can( 'edit_post', $my_post->ID ) ) {
+			return array(
+				'type'      => 'post',
+				'id'        => $my_post->ID,
+				'postID'    => $my_post->ID,
+				'isTrashed' => true,
+				'unixtime'  => 0,
+			);
+		}
+
 		remove_filter( 'the_content', array( 'o2', 'add_json_data' ), 999999 ); // Avoid infinite loops
 		remove_filter( 'the_excerpt', array( 'o2', 'add_json_data' ), 999999 ); // Avoid infinite loops
 

--- a/inc/read-api.php
+++ b/inc/read-api.php
@@ -287,8 +287,14 @@ class o2_Read_API extends o2_API_Base {
 
 		// Override post stati on $args as read is unauthenticated
 		$args = array();
-		if ( isset( $_REQUEST['queryVars'] ) ) {
-			$args = $_REQUEST['queryVars'];
+		if ( isset( $_REQUEST['queryVars'] ) && is_array( $_REQUEST['queryVars'] ) ) {
+			// This endpoint is unauthenticated, so only the query vars o2 itself
+			// bootstraps to the client may be honoured; anything else is attacker
+			// supplied. Same allow list as o2::register_plugin_scripts().
+			$query_vars         = wp_unslash( $_REQUEST['queryVars'] );
+			$allowed_query_vars = apply_filters( 'o2_query_vars', o2::O2_QUERY_VARS );
+			$allowed            = array_intersect_key( $query_vars, array_flip( $allowed_query_vars ) );
+			$args               = array_filter( apply_filters( 'o2_sanitized_query_vars', $allowed ) );
 		}
 
 		$args['post_status'] = $post_stati;
@@ -301,6 +307,11 @@ class o2_Read_API extends o2_API_Base {
 			'suppress_filters'    => false,
 		);
 		$query_args = wp_parse_args( $args, $defaults );
+
+		// The recency bound is enforced by the posts_where filter above, and core
+		// skips every posts_* filter when suppress_filters is true. Never let the
+		// request turn it on.
+		$query_args['suppress_filters'] = false;
 
 		// If we are on a page, change the query post_type to page, otherwise
 		// we will get no data (and updates to pages will not be sent to polling

--- a/o2.php
+++ b/o2.php
@@ -32,6 +32,14 @@ define( 'O2__FILE__', __FILE__ );
 define( 'O2__DIR__', dirname( O2__FILE__ ) );
 
 class o2 {
+	const O2_QUERY_VARS = array(
+		'author', 'author_name',                                           // Author
+		'cat', 'category_name', 'tag', 'tag_id', 'tax_query',              // Taxonomy
+		'year', 'monthnum', 'day', 'hour', 'minute', 'second', 'm', 'w',   // Time
+		'p', 'name', 'page_id', 'pagename', 'page', 'paged',               // Post
+		's',                                                               // Search
+	);
+
 	public $xposts;
 	public $tags;
 	public $keyboard;
@@ -307,13 +315,7 @@ class o2 {
 		global $wp_query;
 		$query_vars = $wp_query->query_vars;
 		$sanitized_query_vars = array();
-		$allowed_query_vars = apply_filters( 'o2_query_vars', array(
-			'author', 'author_name',                                           // Author
-			'cat', 'category_name', 'tag', 'tag_id', 'tax_query',              // Taxonomy
-			'year', 'monthnum', 'day', 'hour', 'minute', 'second', 'm', 'w',   // Time
-			'p', 'name', 'page_id', 'pagename', 'page', 'paged',               // Post
-			's',                                                               // Search
-		) );
+		$allowed_query_vars = apply_filters( 'o2_query_vars', o2::O2_QUERY_VARS );
 		foreach ( $query_vars as $query_var => $value ) {
 			if ( in_array( $query_var, $allowed_query_vars ) && ! empty( $value ) )
 				$sanitized_query_vars[ $query_var ] = $value;


### PR DESCRIPTION
Fixes:

1. Query vars from the request went straight into `WP_Query`
2. Trashed posts were served with their content

## Notes

- No behavior change for logged-in users who can edit the post: they still get the full fragment, including for trashed posts they can edit.
- No behavior change for published posts on any path.
- The outbound allow list in `o2.php` keeps the same members in the same order; only its source moved to the constant.
- `php -l` clean on all three files.
