### PR TITLE
Preserve encoded text when linking hashtags

### DIFF
--- a/inc/tags.php
+++ b/inc/tags.php
@@ -183,7 +183,9 @@ class o2_Tags extends o2_Terms_In_Comments {
 				$parent = $parent->parentNode;
 			}
 
-			$text = $textNode->nodeValue;
+			// DOMDocument decodes entities in nodeValue. Re-escape the text before
+			// adding trusted link markup and parsing the combined fragment again.
+			$text = htmlspecialchars( $textNode->nodeValue, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8' );
 
 			$totalCount = 0;
 			foreach ( $tags as $tag ) {
@@ -203,7 +205,7 @@ class o2_Tags extends o2_Terms_In_Comments {
 				}
 
 				$count = 0;
-				$text = preg_replace( "/(^|\s|>|\()#$tag(($|\b|\s|<|\)))/", '$1' . $replacement . '$2', $text, -1, $count );
+				$text = preg_replace( "/(^|\s|>|&gt;|\()#$tag(($|\b|\s|<|\)))/", '$1' . $replacement . '$2', $text, -1, $count );
 				$totalCount += $count;
 			}
 

--- a/tests/phpunit/test-tags.php
+++ b/tests/phpunit/test-tags.php
@@ -1,0 +1,36 @@
+<?php
+
+class TagsTest extends WP_UnitTestCase {
+
+	function test_tag_links_keeps_encoded_html_as_text() {
+		$term = wp_insert_term( 'security-regression', 'post_tag' );
+		$this->assertFalse( is_wp_error( $term ) );
+
+		$content = '<strong>Allowed markup</strong> &lt;xss-probe data-marker=&quot;unsafe&quot;&gt; #security-regression';
+		$result  = o2_Tags::tag_links( $content );
+
+		$dom = new DOMDocument();
+		libxml_use_internal_errors( true );
+		$dom->loadHTML( '<?xml encoding="UTF-8">' . $result );
+		libxml_use_internal_errors( false );
+
+		$this->assertEquals( 0, $dom->getElementsByTagName( 'xss-probe' )->length );
+		$this->assertEquals( 1, $dom->getElementsByTagName( 'a' )->length );
+		$this->assertEquals( 1, $dom->getElementsByTagName( 'strong' )->length );
+		$this->assertNotFalse( strpos( $result, '&lt;xss-probe' ) );
+	}
+
+	function test_tag_links_preserves_greater_than_boundary() {
+		$term = wp_insert_term( 'boundary-regression', 'post_tag' );
+		$this->assertFalse( is_wp_error( $term ) );
+
+		$result = o2_Tags::tag_links( '&gt;#boundary-regression' );
+
+		$dom = new DOMDocument();
+		libxml_use_internal_errors( true );
+		$dom->loadHTML( '<?xml encoding="UTF-8">' . $result );
+		libxml_use_internal_errors( false );
+
+		$this->assertEquals( 1, $dom->getElementsByTagName( 'a' )->length );
+	}
+}


### PR DESCRIPTION
## Changes proposed in this Pull Request

- Preserve encoded text when the hashtag linkifier rebuilds DOM fragments.
- Keep the existing greater-than tag boundary and allowed-markup behavior.
- Add regression coverage for encoded text and hashtag links.

## Testing instructions

1. Create a tag named `security-regression`.
2. Pass encoded markup followed by `#security-regression` through `o2_Tags::tag_links()`.
3. Confirm the encoded markup remains text and the hashtag becomes a link.
4. Confirm `>#security-regression` still becomes a link.

Checks run:

- `php -l inc/tags.php`
- `php -l tests/phpunit/test-tags.php`
- The corresponding P2 integration flow passed in a fresh logged-out browser; [before/after evidence](https://github.com/Automattic/p2/pull/6739#issuecomment-5498224082).