### PR TITLE
Protect comments returned by the read API

### DIFF
--- a/inc/fragment.php
+++ b/inc/fragment.php
@@ -296,6 +296,21 @@ class o2_Fragment {
 	}
 
 	public static function get_fragment_from_comment( $my_comment ) {
+		// Return only the fields the client needs to remove a trashed comment from the UI.
+		if ( 'trash' === $my_comment->comment_approved && ! current_user_can( 'edit_comment', $my_comment->comment_ID ) ) {
+			return array(
+				'type'            => 'comment',
+				'id'              => $my_comment->comment_ID,
+				'postID'          => $my_comment->comment_post_ID,
+				'parentID'        => $my_comment->comment_parent,
+				'contentFiltered' => '',
+				'unixtime'        => 0,
+				'approved'        => false,
+				'isTrashed'       => true,
+				'hasChildren'     => (bool) get_comment_meta( $my_comment->comment_ID, 'o2_comment_has_children', true ),
+			);
+		}
+
 		add_filter( 'home_url', array( 'o2_Fragment', 'home_url' ), 10, 4 );
 
 		// Update the global comment variable for methods like get_comment_ID used by comment_like_current_user_likes

--- a/inc/read-api.php
+++ b/inc/read-api.php
@@ -72,6 +72,10 @@ class o2_Read_API extends o2_API_Base {
 			}
 			if ( count( $comments ) ) {
 				foreach ( $comments as $comment ) {
+					if ( ! self::current_user_can_read_post( $comment->comment_post_ID ) ) {
+						continue;
+					}
+
 					$data[] = o2_Fragment::get_fragment( $comment );
 				}
 			}
@@ -447,6 +451,33 @@ class o2_Read_API extends o2_API_Base {
 		}
 
 		return $comments;
+	}
+
+	/**
+	 * Whether the current user may see a given post through the read API.
+	 *
+	 * @param int $post_id Post ID.
+	 * @return bool
+	 */
+	private static function current_user_can_read_post( $post_id ) {
+		if ( empty( $post_id ) ) {
+			return false;
+		}
+
+		$post = get_post( $post_id );
+		if ( ! $post ) {
+			return false;
+		}
+
+		if ( current_user_can( 'edit_post', $post->ID ) ) {
+			return true;
+		}
+
+		if ( ! empty( $post->post_password ) ) {
+			return false;
+		}
+
+		return is_post_publicly_viewable( $post ) || current_user_can( 'read_post', $post->ID );
 	}
 
 	/**

--- a/tests/phpunit/test-fragment.php
+++ b/tests/phpunit/test-fragment.php
@@ -263,6 +263,64 @@ class FragmentTest extends WP_UnitTestCase {
 		);
 	}
 
+	function test_trashed_comment_fragment_withholds_content_from_unauthorized_users() {
+		wp_set_current_user( 0 );
+
+		$post = $this->factory->post->create_and_get( array(
+			'post_title'  => 'Private fragment details',
+			'post_status' => 'publish',
+		) );
+
+		$comment = $this->factory->comment->create_and_get( array(
+			'comment_content'  => 'Sensitive trashed comment content',
+			'comment_approved' => 'trash',
+			'comment_post_ID'  => $post->ID,
+			'comment_parent'   => 17,
+		) );
+
+		update_comment_meta( $comment->comment_ID, 'o2_comment_has_children', true );
+
+		$this->assertSame(
+			array(
+				'type'            => 'comment',
+				'id'              => $comment->comment_ID,
+				'postID'          => $comment->comment_post_ID,
+				'parentID'        => $comment->comment_parent,
+				'contentFiltered' => '',
+				'unixtime'        => 0,
+				'approved'        => false,
+				'isTrashed'       => true,
+				'hasChildren'     => true,
+			),
+			o2_Fragment::get_fragment_from_comment( $comment )
+		);
+	}
+
+	function test_trashed_comment_fragment_retains_content_for_authorized_users() {
+		$author_id = $this->factory->user->create( array(
+			'role' => 'administrator',
+		) );
+		wp_set_current_user( $author_id );
+
+		$post = $this->factory->post->create_and_get( array(
+			'post_author' => $author_id,
+			'post_status' => 'publish',
+		) );
+
+		$comment = $this->factory->comment->create_and_get( array(
+			'comment_content'  => 'Authorized trashed comment content',
+			'comment_approved' => 'trash',
+			'comment_post_ID'  => $post->ID,
+		) );
+
+		$fragment = o2_Fragment::get_fragment_from_comment( $comment );
+
+		$this->assertSame( $comment->comment_content, $fragment['contentRaw'] );
+		$this->assertTrue( $fragment['isTrashed'] );
+
+		wp_set_current_user( 0 );
+	}
+
 	function test_get_depth_for_comment() {
 
 		$grandparent = $this->factory->comment->create_and_get( array(


### PR DESCRIPTION
## What changed

- Skip comments whose parent post the caller cannot read.
- Return only a deletion tombstone for trashed comments unless the caller can moderate them.
- Keep full trashed-comment fragments available to authorized moderators.

## Testing

- Passed PHP syntax checks.
- Passed the full FragmentTest suite: 21 tests and 49 assertions.
- Passed an anonymous headless-browser poll against WordPress: the public control remained visible, while private-parent comments and trashed comment content and author metadata were absent.