### PR TITLE
Render edited checklist text safely

### DIFF
--- a/modules/checklists/js/views/common.js
+++ b/modules/checklists/js/views/common.js
@@ -167,7 +167,7 @@ var ChecklistsExtendsCommon = ( function( $ ) {
 			this.options.ignoreTaskBlur = false;
 
 			if ( newItemText.length ) {
-				containingItem.find( '.o2-task-item-text' ).html( newItemText ).show();
+				containingItem.find( '.o2-task-item-text' ).text( newItemText ).show();
 				var command = containingItem.hasClass( 'o2-task-new' ) ? 'add' : 'update';
 				this.sendChecklistRequest( containingItem, command, newItemText, 0 );
 				this.checkListResumeUpdates();


### PR DESCRIPTION
Checklist task edits rendered the input value through jQuery `.html()` before the server's sanitized response replaced it. Render the immediate value with `.text()` so HTML-like task text stays inert.

Companion P2 change: https://github.com/Automattic/p2/pull/6741

## Testing

- `npx grunt jshint`—80 files lint-free
- Confirmed the companion P2 browser regression fails against the vulnerable code and passes with this change
