### PR TITLE
Keep editor content inside the textarea

### DIFF
--- a/js/editor/editor.js
+++ b/js/editor/editor.js
@@ -188,10 +188,13 @@ o2Editor = {
 						<input type="text" class="o2-title o2-editor-title" value="' + title + '" placeholder="' + o2.strings.enterTitleHere + '" /> \
 					</div>';
 					}
-				editor += '<textarea class="o2-editor-text" placeholder="' + prompt + '">' + content + '</textarea> \
+				editor += '<textarea class="o2-editor-text"></textarea> \
 				<div class="o2-editor-preview"></div> \
 			</div> \
 		</div>';
+
+		editor = $( editor );
+		editor.find( '.o2-editor-text' ).attr( 'placeholder', prompt ).val( content );
 
 		return editor;
 	},

--- a/tests/qunit/editor.js
+++ b/tests/qunit/editor.js
@@ -1,0 +1,41 @@
+/* global jQuery, o2Editor, QUnit */
+
+QUnit.module( 'Editor', {
+	afterEach: function() {
+		jQuery( '#qunit-fixture' ).empty();
+	}
+} );
+
+QUnit.test( 'rebuild keeps stored content inside the textarea', function( assert ) {
+	var content = 'Ordinary text </textarea><div id="o2-editor-proof">markup-like text</div>',
+		fixture = jQuery( '#qunit-fixture' );
+
+	fixture.html(
+		'<textarea class="o2-editor" title="Quoted &quot;title&quot;" placeholder="Write something">' +
+		'Ordinary text &lt;/textarea&gt;&lt;div id=&quot;o2-editor-proof&quot;&gt;markup-like text&lt;/div&gt;' +
+		'</textarea>'
+	);
+
+	o2Editor.detectAndRender( fixture );
+
+	assert.strictEqual(
+		fixture.find( '#o2-editor-proof' ).length,
+		0,
+		'stored content does not create sibling elements'
+	);
+	assert.strictEqual(
+		fixture.find( '.o2-editor-text' ).val(),
+		content,
+		'stored content remains the editor value'
+	);
+	assert.strictEqual(
+		fixture.find( '.o2-editor-text' ).attr( 'placeholder' ),
+		'Write something',
+		'the placeholder is preserved'
+	);
+	assert.strictEqual(
+		fixture.find( '.o2-editor-title' ).val(),
+		'Quoted "title"',
+		'the title is preserved'
+	);
+} );

--- a/tests/qunit/index.html
+++ b/tests/qunit/index.html
@@ -8,6 +8,7 @@
 
 		<!-- General Dependencies -->
 		<script src="../../../../../wp-includes/js/jquery/jquery.js"></script>
+		<script src="../../../../../wp-includes/js/underscore.min.js"></script>
 
 		<!-- 
 		These other ones aren't needed yet, but may be down the line
@@ -19,6 +20,24 @@
 		-->
 
 		<!-- Plugin Dependencies -->
+		<script>
+			window.o2 = {
+				strings: {
+					bold: 'Bold',
+					italics: 'Italics',
+					link: 'Link',
+					image: 'Image',
+					blockquote: 'Blockquote',
+					code: 'Code',
+					addPostTitle: 'Add title',
+					enterTitleHere: 'Enter title here'
+				},
+				options: {
+					appContainer: '#qunit-fixture'
+				}
+			};
+		</script>
+		<script src="../../js/editor/editor.js"></script>
 		<script src="../../modules/time-shortcode/js/time-shortcode.js"></script>
 
 	</head>
@@ -31,6 +50,7 @@
 		<script>QUnit.config.hidepassed = false;</script>
 
 		<!-- Test Suites -->
+		<script src="editor.js"></script>
 		<script src="modules/time-shortcode.js"></script>
 	</body>
 </html>


### PR DESCRIPTION
The legacy editor rebuilt a server-rendered textarea by inserting its decoded value into a new HTML string. This change creates the textarea empty, then copies its placeholder and value through DOM APIs.

It also adds a QUnit browser regression covering content containment, title preservation, and placeholder preservation.

## Testing

- `npx grunt jshint`—80 files lint-free
- `npx jshint tests/qunit/editor.js`
- QUnit browser suite—10 assertions passed
- Legacy o2 browser flow—edit, preview, and return to edit passed

