### PR TITLE
Escape live widget post titles

### DIFF
--- a/modules/live-comments/js/views/item.js
+++ b/modules/live-comments/js/views/item.js
@@ -41,7 +41,7 @@ o2.Views.LiveCommentsWidgetItemView = ( function( $ ) {
 				titleTemplate = o2.Utilities.Template( 'live-comment-title-template' );
 				titleForItem = titleTemplate( jsonifiedModel );
 			}
-			jsonifiedModel.title = titleForItem;
+			jsonifiedModel.title = _.unescape( titleForItem );
 
 			var template = o2.Utilities.Template( 'live-item-template' );
 

--- a/modules/live-comments/load.php
+++ b/modules/live-comments/load.php
@@ -40,7 +40,7 @@ class o2_Live_Comments_Widget extends WP_Widget {
 					<# if ( 'comment' === data.type ) { #>
 						data-postid="{{ data.postID }}"
 					<# } #>
-					>{{{ data.title }}}</a>
+					>{{ data.title }}</a>
 					<br/>
 					<span class="entry-date o2-timestamp" data-unixtime="{{ data.unixtime }}" data-domref="{{ data.domRef }}"
 						<# if ( 'comment' === data.type ) { #>


### PR DESCRIPTION
Render Live Posts and Comments widget post titles as text at the final template boundary. This preserves translated untitled labels and long-word shortening without reparsing title content as HTML.

Replaces #243 with a smaller fix that does not create an intermediate DOM tree.

Testing:
- npx grunt jshint
- Browser regression in the paired P2 source change