### PR TITLE
Use object capabilities for checklist actions

### DIFF
--- a/modules/checklists/load.php
+++ b/modules/checklists/load.php
@@ -95,12 +95,6 @@ class o2_List_Creator {
 			return true;
 		}
 
-		// o2 also allows authors to do checklist things
-		$user_data = get_userdata( $current_user_id );
-		if ( in_array( 'author', $user_data->roles ) ) {
-			return true;
-		}
-
 		return false;
 	}
 


### PR DESCRIPTION
## What changed

Checklist actions now rely on WordPress object-level capabilities for the requested post or comment. The role-name exception has been removed, so permissions remain tied to each object.

## Testing

- PHP 8.4 syntax check
- Browser regression coverage in https://github.com/Automattic/p2/pull/6744 for author-owned content, protected content owned by another author, and editor access
