### PR TITLE
Drop the Travis-named Grunt tasks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
           node-version: 22
           cache: npm
       - run: npm ci
-      - run: npx grunt travis:lint
+      - run: npx grunt lint
 
   phpunit:
     runs-on: ubuntu-latest

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -138,6 +138,5 @@ module.exports = function(grunt) {
 		}, this.async());
 	});
 
-	grunt.registerTask( 'travis:lint', 'Runs code linting Travis CI tasks', [ 'phplint', 'jshint' ] );
-	grunt.registerTask( 'travis:phpunit', 'Runs PHPUnit Travis CI tasks.', 'phpunit' );
+	grunt.registerTask( 'lint', 'Runs PHP and JavaScript lint checks.', [ 'phplint', 'jshint' ] );
 };

--- a/HACKING.txt
+++ b/HACKING.txt
@@ -57,6 +57,6 @@ There are a number of core modules provided, which will give you an idea on how 
 ## Testing
 * Run 'composer install' to get PHPUnit and the polyfills the WordPress test library needs
 * Run 'bash bin/install-wp-tests.sh <db-name> <db-user> <db-pass> [db-host] [wp-version]' once to install WordPress and its test library into /tmp (needs git and a MySQL server)
-* Run 'vendor/bin/phpunit' (or 'grunt travis:phpunit') for the PHP tests
+* Run 'vendor/bin/phpunit' (or 'grunt phpunit') for the PHP tests
 * Run 'grunt qunit' for the JavaScript tests. The test page loads jQuery and Underscore from WordPress core, so the plugin has to sit at wp-content/plugins/o2 inside a WordPress install
 * 'npm test' runs lint, PHPUnit, and QUnit together

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
 	"description": "Front-page editing and live-updating posts/comments for your site.",
 	"main": "o2.php",
 	"scripts": {
-		"test": "grunt travis:lint travis:phpunit qunit"
+		"test": "grunt lint phpunit qunit"
 	},
 	"repository": {
 		"type": "git",


### PR DESCRIPTION
Follow-up to #254. The Grunt tasks kept their Travis-era names after Travis was removed.

- `travis:lint` is now `lint`.
- `travis:phpunit` is gone. It was an alias for the existing `phpunit` task, which does the same thing.
- The `npm test` script, the CI workflow, and HACKING.txt use the plain names.

No behavior change. `grunt lint` passes locally (52 PHP files, 80 JS files), and `grep -ri travis` finds nothing left outside `.git`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
