### PR TITLE
Let authors edit checklists in their own comments

### DIFF
--- a/modules/checklists/load.php
+++ b/modules/checklists/load.php
@@ -81,7 +81,7 @@ class o2_List_Creator {
 		return $this->parse_lists( $content );
 	}
 
-	function current_user_can_edit_checklist( $object_type, $object_ID ) {
+	public function current_user_can_edit_checklist( $object_type, $object_id ) {
 		// no logged out edits, evar
 		$current_user_id = get_current_user_id();
 		if ( 0 == $current_user_id ) {
@@ -89,10 +89,14 @@ class o2_List_Creator {
 		}
 
 		// try default post and comment capabilities
-		if ( ( 'post' == $object_type ) && ( current_user_can( 'edit_post', $object_ID ) ) ) {
+		if ( ( 'post' == $object_type ) && ( current_user_can( 'edit_post', $object_id ) ) ) {
 			return true;
-		} else if ( ( 'comment' == $object_type ) && ( current_user_can( 'edit_comment', $object_ID ) ) ) {
-			return true;
+		} else if ( 'comment' == $object_type ) {
+			// Apply o2's comment rule: authors always edit their own comments
+			add_filter( 'map_meta_cap', array( 'o2_Write_API', 'restrict_comment_editing' ), 10, 4 );
+			$user_can_edit_comment = current_user_can( 'edit_comment', $object_id );
+			remove_filter( 'map_meta_cap', array( 'o2_Write_API', 'restrict_comment_editing' ), 10 );
+			return $user_can_edit_comment;
 		}
 
 		return false;

--- a/tests/phpunit/modules/test-checklists.php
+++ b/tests/phpunit/modules/test-checklists.php
@@ -55,6 +55,19 @@ class o2ChecklistsTest extends WP_UnitTestCase {
 		$this->assertStringNotContainsString( 'o2-task-tools', $rendered, 'The task tools should not be rendered' );
 	}
 
+	function test_editor_can_edit_checklist_in_another_users_comment() {
+		$editor_id = $this->factory->user->create( array( 'role' => 'editor' ) );
+		$author_id = $this->factory->user->create( array( 'role' => 'author' ) );
+		$comment_id = $this->create_comment_on_another_authors_post( $author_id );
+
+		wp_set_current_user( $editor_id );
+
+		$this->assertTrue(
+			$this->list_creator->current_user_can_edit_checklist( 'comment', $comment_id ),
+			'An editor should be able to edit checklists in any comment'
+		);
+	}
+
 	function test_logged_out_user_cannot_edit_checklist_in_comment() {
 		$author_id = $this->factory->user->create( array( 'role' => 'author' ) );
 		$comment_id = $this->create_comment_on_another_authors_post( $author_id );

--- a/tests/phpunit/modules/test-checklists.php
+++ b/tests/phpunit/modules/test-checklists.php
@@ -1,0 +1,66 @@
+<?php
+
+class o2ChecklistsTest extends WP_UnitTestCase {
+
+	private $list_creator;
+
+	function setUp(): void {
+		parent::setUp();
+		$this->list_creator = new o2_List_Creator();
+	}
+
+	private function create_comment_on_another_authors_post( $commenter_id ) {
+		$post_owner_id = $this->factory->user->create( array( 'role' => 'author' ) );
+		$post_id = $this->factory->post->create( array( 'post_author' => $post_owner_id ) );
+
+		return $this->factory->comment->create( array(
+			'comment_post_ID' => $post_id,
+			'user_id' => $commenter_id,
+			'comment_content' => 'o my task',
+		) );
+	}
+
+	function test_author_can_edit_checklist_in_own_comment_on_another_authors_post() {
+		$author_id = $this->factory->user->create( array( 'role' => 'author' ) );
+		$comment_id = $this->create_comment_on_another_authors_post( $author_id );
+
+		wp_set_current_user( $author_id );
+
+		$this->assertTrue(
+			$this->list_creator->current_user_can_edit_checklist( 'comment', $comment_id ),
+			'An author should be able to edit checklists in their own comment'
+		);
+
+		$rendered = $this->list_creator->parse_lists_in_comment( 'o my task', get_comment( $comment_id ) );
+
+		$this->assertStringNotContainsString( 'disabled', $rendered, 'The checkbox should be enabled' );
+		$this->assertStringContainsString( 'o2-task-tools', $rendered, 'The task tools should be rendered' );
+	}
+
+	function test_author_cannot_edit_checklist_in_another_users_comment() {
+		$author_id = $this->factory->user->create( array( 'role' => 'author' ) );
+		$other_author_id = $this->factory->user->create( array( 'role' => 'author' ) );
+		$comment_id = $this->create_comment_on_another_authors_post( $other_author_id );
+
+		wp_set_current_user( $author_id );
+
+		$this->assertFalse(
+			$this->list_creator->current_user_can_edit_checklist( 'comment', $comment_id ),
+			'An author should not be able to edit checklists in another user\'s comment'
+		);
+
+		$rendered = $this->list_creator->parse_lists_in_comment( 'o my task', get_comment( $comment_id ) );
+
+		$this->assertStringContainsString( 'disabled', $rendered, 'The checkbox should be disabled' );
+		$this->assertStringNotContainsString( 'o2-task-tools', $rendered, 'The task tools should not be rendered' );
+	}
+
+	function test_logged_out_user_cannot_edit_checklist_in_comment() {
+		$author_id = $this->factory->user->create( array( 'role' => 'author' ) );
+		$comment_id = $this->create_comment_on_another_authors_post( $author_id );
+
+		wp_set_current_user( 0 );
+
+		$this->assertFalse( $this->list_creator->current_user_can_edit_checklist( 'comment', $comment_id ) );
+	}
+}


### PR DESCRIPTION
## What changed

Checklist authorization for comments now runs the existing `o2_Write_API::restrict_comment_editing()` capability filter around the `edit_comment` check, the same way the comment Edit and Trash actions already do. Authors can tick, edit, delete, and add checklist items in comments they wrote on posts owned by other users. Other users' comments still need `moderate_comments`.

WordPress core maps `edit_comment` to the parent post's edit capabilities and never consults the comment's author, so after #255 removed the role-name fallback an Author lost checklist access to their own comments on someone else's post. The rendered checkbox came out disabled and the AJAX request was refused.

The method is now declared `public` and its parameter renamed to `$object_id` so the WordPress.com mirror passes its coding-standards gate. Behavior is otherwise unchanged.

## Testing

- New PHPUnit coverage in `tests/phpunit/modules/test-checklists.php`: an Author's own comment on another Author's post is editable and renders enabled; another user's comment is not editable and renders disabled; logged-out users are denied. The first test fails with the fix reverted.
- Full suite: 85 tests, 150 assertions pass locally against WordPress 7.1.
- Browser regression coverage in https://github.com/Automattic/p2/pull/6745: an Author's own comment on another user's post renders an enabled checkbox and accepts an update, while the post owner's comment renders disabled and refuses the update.
