### PR TITLE
Follow: resolve the request endpoint from the post, and require same origin

### DIFF
--- a/modules/follow/js/views/post.js
+++ b/modules/follow/js/views/post.js
@@ -14,6 +14,16 @@ var FollowExtendsPost = ( function() {
 			'touchend a.o2-follow':   'updateFollow'
 		},
 
+		// True when a url resolves to the origin the page was served from.
+		// Assigning to an anchor lets the browser normalise relative and
+		// protocol-relative forms before the comparison.
+		isSameOrigin: function( url ) {
+			var resolver = document.createElement( 'a' );
+			resolver.href = url;
+			return resolver.protocol + '//' + resolver.host ===
+				window.location.protocol + '//' + window.location.host;
+		},
+
 		updateFollow: function( event ) {
 			if ( 'undefined' !== typeof event ) {
 				event.preventDefault();
@@ -24,9 +34,20 @@ var FollowExtendsPost = ( function() {
 				return; // we don't allow them to unfollow all with this ui
 			}
 
-			// Get the current AJAX link
-			var link = this.$( '.o2-follow' );
+			// Get the current AJAX link. The article this view owns also holds
+			// the comment list, and comment bodies are author-supplied HTML,
+			// so look the control up inside the post rather than across the
+			// whole view.
+			var link = this.$post().find( '.o2-follow' );
 			var href = link.attr( 'href' );
+
+			// The model's sync() sends the o2 nonce, with credentials, to
+			// whatever url it is handed. The rendered control is built from
+			// home_url(), so anything pointing off-origin did not come from
+			// our own markup and must not receive that request.
+			if ( ! href || ! this.isSameOrigin( href ) ) {
+				return;
+			}
 
 			// Update the model
 			this.model.changeFollow();

--- a/modules/follow/js/views/post.js
+++ b/modules/follow/js/views/post.js
@@ -14,14 +14,19 @@ var FollowExtendsPost = ( function() {
 			'touchend a.o2-follow':   'updateFollow'
 		},
 
-		// True when a url resolves to the origin the page was served from.
-		// Assigning to an anchor lets the browser normalise relative and
-		// protocol-relative forms before the comparison.
-		isSameOrigin: function( url ) {
+		// True when a url resolves to the host the page was served from.
+		// Assigning to an anchor lets the browser normalise relative,
+		// protocol-relative and percent-encoded forms, and resolve any
+		// userinfo, before the comparison.
+		//
+		// Host rather than full origin: the endpoint is allowed to differ in
+		// protocol from the page. o2 upgrades http to https for permalinks
+		// generated during ajax calls (o2_Fragment::home_url), and the
+		// withCredentials note in js/models/base.js records the same case.
+		isSameHost: function( url ) {
 			var resolver = document.createElement( 'a' );
 			resolver.href = url;
-			return resolver.protocol + '//' + resolver.host ===
-				window.location.protocol + '//' + window.location.host;
+			return !! resolver.host && resolver.host === window.location.host;
 		},
 
 		updateFollow: function( event ) {
@@ -40,12 +45,18 @@ var FollowExtendsPost = ( function() {
 			// whole view.
 			var link = this.$post().find( '.o2-follow' );
 			var href = link.attr( 'href' );
+			if ( ! href ) {
+				return;
+			}
+
+			// Check the url we are actually going to send, not the href we
+			// started from: appending to a href that carries no query string
+			// extends its host rather than its query.
+			var requestURL = href + '&ajax';
 
 			// The model's sync() sends the o2 nonce, with credentials, to
-			// whatever url it is handed. The rendered control is built from
-			// home_url(), so anything pointing off-origin did not come from
-			// our own markup and must not receive that request.
-			if ( ! href || ! this.isSameOrigin( href ) ) {
+			// whatever url it is handed, so only send to our own host.
+			if ( ! this.isSameHost( requestURL ) ) {
 				return;
 			}
 
@@ -62,7 +73,7 @@ var FollowExtendsPost = ( function() {
 			this.model.save( {}, {
 				patch: true,
 				silent: true,
-				url: href + '&ajax',
+				url: requestURL,
 				success: this.saveFollowSuccess,
 				error: this.saveFollowError
 			} );
@@ -94,7 +105,7 @@ var FollowExtendsPost = ( function() {
 		},
 
 		updateFollowView: function() {
-			var link = this.$( '.o2-follow' );
+			var link = this.$post().find( '.o2-follow' );
 			if ( ! link.length ) {
 				return;
 			}

--- a/modules/follow/js/views/post.js
+++ b/modules/follow/js/views/post.js
@@ -14,15 +14,7 @@ var FollowExtendsPost = ( function() {
 			'touchend a.o2-follow':   'updateFollow'
 		},
 
-		// True when a url resolves to the host the page was served from.
-		// Assigning to an anchor lets the browser normalise relative,
-		// protocol-relative and percent-encoded forms, and resolve any
-		// userinfo, before the comparison.
-		//
-		// Host rather than full origin: the endpoint is allowed to differ in
-		// protocol from the page. o2 upgrades http to https for permalinks
-		// generated during ajax calls (o2_Fragment::home_url), and the
-		// withCredentials note in js/models/base.js records the same case.
+		// Host, not origin: the endpoint may differ in protocol from the page.
 		isSameHost: function( url ) {
 			var resolver = document.createElement( 'a' );
 			resolver.href = url;
@@ -39,23 +31,14 @@ var FollowExtendsPost = ( function() {
 				return; // we don't allow them to unfollow all with this ui
 			}
 
-			// Get the current AJAX link. The article this view owns also holds
-			// the comment list, and comment bodies are author-supplied HTML,
-			// so look the control up inside the post rather than across the
-			// whole view.
 			var link = this.$post().find( '.o2-follow' );
 			var href = link.attr( 'href' );
 			if ( ! href ) {
 				return;
 			}
 
-			// Check the url we are actually going to send, not the href we
-			// started from: appending to a href that carries no query string
-			// extends its host rather than its query.
+			// sync() sends the o2 nonce with credentials to whatever url it gets.
 			var requestURL = href + '&ajax';
-
-			// The model's sync() sends the o2 nonce, with credentials, to
-			// whatever url it is handed, so only send to our own host.
 			if ( ! this.isSameHost( requestURL ) ) {
 				return;
 			}


### PR DESCRIPTION
Hardening in the follow module. The description is deliberately light because this repo is public; detail lives in P2HQ-274.

## What changes

`updateFollow()` takes the endpoint for its model save from a DOM lookup:

```js
var link = this.$( '.o2-follow' );
var href = link.attr( 'href' );
this.model.save( {}, { url: href + '&ajax', … } );
```

Two things about that are worth tightening:

1. The lookup ran across the whole view. The view's root element holds the comment list as well as the post, and `.attr()` returns the first match, so the element it resolves to is not necessarily one of ours. It now looks inside the post container, using the `$post()` helper added in #259. `updateFollowView()` gets the same treatment, since it does the same lookup and rewrites the href it finds.
2. The request that url receives carries the o2 nonce and is sent with credentials (`sync()` in `js/models/base.js` sets `params.data.nonce` and `options.xhrFields.withCredentials`, then does `_.extend( params, options )`, so a passed `url` wins). It now declines to send unless that url is on our own host.

The guard sits before `changeFollow()` and `updateFollowView()`, so when it declines nothing has been mutated and the optimistic UI cannot desync.

## Why host and not full origin

Comparing protocol *and* host would reject a legitimate endpoint. The endpoint is allowed to differ in protocol from the page: `o2_Fragment::home_url` upgrades `http` to `https` for permalinks generated during ajax calls, and the `withCredentials` comment in `js/models/base.js` records the same situation (`force_ssl_admin` on, page reached over http). An http page with an https follow endpoint would have stopped working.

Host still includes the port, so origins that differ by port are still distinguished.

## Why the check runs on the request url

The url sent is `href + '&ajax'`. Appending to a href with no query string extends its **host** rather than its query, so checking `href` and sending something else would leave a gap between what was validated and what was requested. The request url is built first and that is what gets checked.

## Verification

Loaded the real mixin into jsdom with real jQuery and Underscore, built the article in the order `inc/tpl/post-view.php` emits it, and intercepted `model.save()` rather than issuing a request:

| Case | `master` | this branch |
|---|---|---|
| Genuine control present | `…/?subscribe=1&_wpnonce=real&ajax` | same — unchanged |
| Genuine control absent, planted one is the only match | `https://evil.example.net/collect?x=1&ajax` | no request sent |
| http page, https endpoint | n/a | sends — the case a protocol comparison would have broken |
| href with no query string | n/a | no request sent |

Separately checked how an anchor resolves each of: protocol-relative `//host`, embedded credentials `https://ours@evil/`, `javascript:`, `data:`, `blob:`, `about:blank`, uppercase scheme, leading whitespace, trailing-dot host, IDN/punycode, and explicit ports. Every off-host form resolves to a host that fails the comparison; relative and same-host forms pass.

Confirmed the scoping is safe for every path where these handlers run. The control is registered through `o2_filter_post_actions`, the same mechanism as `.o2-trash`, which renders inside `.o2-post`. A second render path emits an `o2-follow` anchor directly, but it is hooked on `p2_action_links` — the classic P2 theme, which does not run this Backbone view. The `update-follow` model event fires with no arguments, so the existing `typeof event` branch still covers that call path.

`npx grunt lint` passes: 53 PHP files, 80 JS files lint free.

## Not included

`updateFollow` remains *reachable* from a control placed anywhere in the view, as do the sticky and resolve mixins — so a click on a planted element can still toggle the visitor's real subscription on the real endpoint. That is a state change, not a credential leak, and it needs an ownership check rather than an endpoint check. Tracked separately; this PR is limited to where the endpoint comes from.
