### PR TITLE
Only act on post-action controls that belong to the post

### DIFF
--- a/js/views/post.js
+++ b/js/views/post.js
@@ -220,6 +220,10 @@ o2.Views.Post = ( function( $ ) {
 		},
 
 		onShortLinkClick: function( event ) {
+			if ( ! this.isPostControl( event ) ) {
+				return;
+			}
+
 			var shortLink = event.target.href;
 			event.preventDefault();
 			event.stopPropagation();

--- a/modules/follow/js/views/post.js
+++ b/modules/follow/js/views/post.js
@@ -22,6 +22,10 @@ var FollowExtendsPost = ( function() {
 		},
 
 		updateFollow: function( event ) {
+			if ( event && ! this.isPostControl( event ) ) {
+				return;
+			}
+
 			if ( 'undefined' !== typeof event ) {
 				event.preventDefault();
 				event.stopPropagation();

--- a/modules/sticky-posts/js/views/extend-post.js
+++ b/modules/sticky-posts/js/views/extend-post.js
@@ -15,6 +15,10 @@ var StickyPostExtendsPost = ( function( $ ) {
 		},
 
 		onClickStickyPost: function( event ) {
+			if ( ! this.isPostControl( event ) ) {
+				return;
+			}
+
 			event.preventDefault();
 			event.stopPropagation();
 

--- a/modules/to-do/js/views/extend-post.js
+++ b/modules/to-do/js/views/extend-post.js
@@ -25,6 +25,10 @@ var ResolvedPostExtendsPost = ( function( $ ) {
 		},
 
 		onClickResolvedPosts: function( event ) {
+			if ( ! this.isPostControl( event ) ) {
+				return;
+			}
+
 			event.preventDefault();
 			event.stopPropagation();
 


### PR DESCRIPTION
Follows #259 and #260. The description is deliberately light because this repo is public; detail lives in P2HQ-274.

## What changes

#259 added an ownership check to the post view's own handlers. The three mixins that extend that view were left delegating from the whole article:

```js
'click a.o2-follow':       'updateFollow',
'click a.o2-sticky-link':  'onClickStickyPost',
'click a.o2-resolve-link': 'onClickResolvedPosts',
```

The article holds the comment list as well as the post, and comment bodies are author-supplied HTML, so a control rendered inside a comment matched the same selectors as the post's own controls. One click ran the parent post's action under the viewer's session — toggling follow, stickying the post, or flipping its resolved state.

This applies the existing `isPostControl()` to all three.

## Why this is safe for the real controls

All three are registered as post actions — `modules/sticky-posts/load.php` and `modules/to-do/load.php` set their classes, and the follow action is registered on `o2_filter_post_actions` — and post actions render through `{{{ data.postActions }}}` in `inc/tpl/post.php`, which is the template `renderPost()` writes into `.o2-post`. So no legitimate control sits inside `.o2-post-comments`, which is the only thing the check excludes.

`updateFollow` keeps its no-event path. It is also invoked by the `update-follow` model event, which the comment-side subscribe checkbox triggers with no arguments — a legitimate route rather than a delegated control — so the guard is applied only when there is an event.

## Verification

jsdom harness loading each real mixin with real jQuery and Underscore, article built in `inc/tpl/post-view.php` order, with the same control class planted inside a comment and rendered legitimately inside `.o2-post`. The model write is intercepted rather than issued:

| Handler | `master`: planted | `master`: legitimate | this branch: planted | this branch: legitimate |
|---|---|---|---|---|
| `updateFollow` | writes | writes | **ignored** | writes |
| `onClickStickyPost` | writes | writes | **ignored** | writes |
| `onClickResolvedPosts` | writes | writes | **ignored** | writes |

`npx grunt lint` passes: 53 PHP files, 80 JS files lint free.

## Not included

The comment-side follow mixin binds `change #subscribe:checkbox` on the comment view and triggers `update-follow`. That is a comment-level control by design, so it is a different shape from the delegated post controls this PR is about and is not covered here.
