### PR TITLE
Save a comment from its own content, not from replies nested inside it

### DIFF
--- a/js/views/comment.js
+++ b/js/views/comment.js
@@ -191,7 +191,7 @@ o2.Views.Comment = ( function( $ ) {
 		$ownFind: function( selector ) {
 			return this.$el
 				.find( selector )
-				.not( this.$el.find( '.o2-child-comments' ).find( selector ) );
+				.not( this.$el.children( '.o2-child-comments' ).find( selector ) );
 		},
 
 		onSave: function( event ) {
@@ -209,7 +209,7 @@ o2.Views.Comment = ( function( $ ) {
 			modelToSave.author = {};
 			modelToSave.contentRaw = this.$ownFind( '.o2-editor-text' ).last().val();
 
-			if ( this.$el.find( '#subscribe_blog' ).prop( 'checked' ) ) {
+			if ( this.$ownFind( '#subscribe_blog' ).prop( 'checked' ) ) {
 				o2.options.followingBlog = true;
 			}
 
@@ -219,9 +219,9 @@ o2.Views.Comment = ( function( $ ) {
 			}
 
 			if ( ! this.options.currentUser.userLogin.length ) {
-				var commentName = this.$el.find( '.o2-comment-name' ).val();
-				var commentEmail = this.$el.find( '.o2-comment-email' ).val();
-				var commentUrl = this.$el.find( '.o2-comment-url' ).val();
+				var commentName = this.$ownFind( '.o2-comment-name' ).val();
+				var commentEmail = this.$ownFind( '.o2-comment-email' ).val();
+				var commentUrl = this.$ownFind( '.o2-comment-url' ).val();
 
 				if ( this.options.requireUserNameAndEmailIfNotLoggedIn ) {
 					if ( commentName.length < 1 ) {

--- a/js/views/comment.js
+++ b/js/views/comment.js
@@ -187,6 +187,13 @@ o2.Views.Comment = ( function( $ ) {
 			o2Editor.finished( this.model.get( 'postID' ), this.model.get( 'parentID' ), args );
 		},
 
+		// This comment's own content, excluding replies nested inside it.
+		$ownFind: function( selector ) {
+			return this.$el
+				.find( selector )
+				.not( this.$el.find( '.o2-child-comments' ).find( selector ) );
+		},
+
 		onSave: function( event ) {
 			o2.Events.doAction( 'pre-comment-save.o2' );
 			event.preventDefault();
@@ -200,14 +207,14 @@ o2.Views.Comment = ( function( $ ) {
 			// Grab the content from the actual textarea (the last one), not the autosize hidden one
 			var modelToSave = {};
 			modelToSave.author = {};
-			modelToSave.contentRaw = this.$el.find( '.o2-editor-text' ).last().val();
+			modelToSave.contentRaw = this.$ownFind( '.o2-editor-text' ).last().val();
 
 			if ( this.$el.find( '#subscribe_blog' ).prop( 'checked' ) ) {
 				o2.options.followingBlog = true;
 			}
 
 			if ( modelToSave.contentRaw.length < 1 ) {
-				this.$el.find( '.o2-editor-text' ).addClass( 'o2-error' );
+				this.$ownFind( '.o2-editor-text' ).addClass( 'o2-error' );
 				requiredInputMissing  = true;
 			}
 
@@ -405,9 +412,9 @@ o2.Views.Comment = ( function( $ ) {
 			this.$el.prepend( template( jsonifiedModel ) );
 
 			if ( this.options.isEditing ) {
-				o2Editor.detectAndRender( this.$el );
+				o2Editor.detectAndRender( this.$el.children().not( '.o2-child-comments' ) );
 
-				var editor = this.$el.find( '.o2-editor-text' );
+				var editor = this.$ownFind( '.o2-editor-text' );
 				editor.data( 'autoTitleDisabled', true );
 
 				o2Editor.create(


### PR DESCRIPTION
Follows #259, #260 and #261. The description is deliberately light because this repo is public; detail lives in P2HQ-274.

## What changes

A comment view's root element contains that comment **and, beneath it, every reply to it**. `js/views/post.js` appends replies into a `.o2-child-comments` div that is a child of the parent comment's element, and `renderComment` prepends the comment's own template ahead of that div.

`onSave` read the editor like this:

```js
modelToSave.contentRaw = this.$el.find( '.o2-editor-text' ).last().val();
```

`.last()` in document order is therefore whichever editor sits deepest in the reply tree — not the one the author typed into.

Comment bodies are author-supplied HTML, so a reply containing a hidden `<textarea class="o2-editor-text">` is what gets saved when the parent comment's author edits and saves their own comment. No control of the attacker's is clicked; it is the ordinary edit-and-save path, and the result is stored under the victim's own account.

Adds `$ownFind()`, which searches the comment's own content and drops anything inside its `.o2-child-comments`, and routes the editor lookups through it. `onSave` also read four other form values straight from the subtree — `#subscribe_blog`, which sets the global `followingBlog` flag that adds `subscribe_blog` to later create requests, and the name, email and url fields that populate a logged-out comment's author. Stock templates put the comment's own inputs ahead of its replies so a first-match read normally wins, but a comment that does not render one of them has no first match and a reply supplies it instead. Those go through `$ownFind` too.

Editor creation is scoped the same way. `o2Editor.detectAndRender( this.$el )` promotes **every** `textarea.o2-editor` in the subtree, so a reply could have one of its textareas turned into an editor belonging to the parent comment — the same shape #259 fixed for the post view.

## Why the boundary is `.o2-child-comments`

It is a direct child of the comment's own element (`js/views/comment.js` re-renders with `this.$el.children().not( '.o2-child-comments' ).remove()`, deliberately leaving replies alone), and it is the only container replies are inserted into (`js/views/post.js`). So "this comment's own content" is exactly the view's subtree minus anything under that div.

## Verification

jsdom harness driving the real view against a comment that has its own editor plus a reply carrying a hidden one:

| | `master` | this branch |
|---|---|---|
| What the author's own save reads | `"ATTACKER TEXT"` | `"VICTIM'S OWN EDIT"` |
| Editors promoted by `detectAndRender` | 2 (including the reply's) | 1 (the comment's own) |
| Same, with a reply-to-a-reply nested deeper | `"DEEPER ATTACKER"` | `"VICTIM'S OWN EDIT"` |
| Name and `subscribe_blog` supplied by a reply | `"ATTACKER NAME"` / `true` | not visible to the save |

`npx grunt lint` passes: 53 PHP files, 80 JS files lint free.

## One caveat on the editor scope

`detectAndRender( $dom )` does `$dom.find( 'textarea.o2-editor' )`, which does not match the supplied elements themselves. Every template in this repo wraps the textarea in a direct-child div (`inc/tpl/comment-edit.php`, `inc/tpl/logged-out-create-comment.php`), so the comment's own editor is found. A template override that placed the textarea directly under the view root would not be, where previously it would. Worth knowing if anyone maintains a custom comment template.

## Not included

`onKeyDown` is bound without a selector, so a command+return anywhere in the subtree reaches every ancestor comment's handler. In this copy `onSave` calls `stopImmediatePropagation()`, so the innermost handler halts the cascade before ancestors run — and with this scoping in place, an ancestor that did run would read its own editor rather than a reply's. That leaves it a correctness question rather than a security one, and it is tracked separately.
