### PR TITLE
Add qunit coverage for the post/comment ownership boundary

### DIFF
--- a/tests/qunit/index.html
+++ b/tests/qunit/index.html
@@ -9,13 +9,12 @@
 		<!-- General Dependencies -->
 		<script src="../../../../../wp-includes/js/jquery/jquery.js"></script>
 		<script src="../../../../../wp-includes/js/underscore.min.js"></script>
+		<script src="../../../../../wp-includes/js/backbone.min.js"></script>
+		<script src="../../../../../wp-includes/js/wp-backbone.js"></script>
 
 		<!-- 
 		These other ones aren't needed yet, but may be down the line
 		<script src="../../../../../wp-includes/js/jquery/ui/core.js"></script>
-		<script src="../../../../../wp-includes/js/underscore.min.js"></script>
-		<script src="../../../../../wp-includes/js/backbone.min.js"></script>
-		<script src="../../../../../wp-includes/js/wp-backbone.js"></script>
 		<script src="../../../../../wp-includes/js/wp-util.js"></script>
 		-->
 
@@ -34,11 +33,20 @@
 				},
 				options: {
 					appContainer: '#qunit-fixture'
-				}
+				},
+				// The views read these when Backbone extends them.
+				Models: {},
+				Collections: {}
 			};
 		</script>
 		<script src="../../js/editor/editor.js"></script>
 		<script src="../../modules/time-shortcode/js/time-shortcode.js"></script>
+		<script src="../../js/views/post.js"></script>
+		<script src="../../js/views/comment.js"></script>
+		<script src="../../js/utils/cocktail.js"></script>
+		<script src="../../modules/sticky-posts/js/views/extend-post.js"></script>
+		<script src="../../modules/to-do/js/views/extend-post.js"></script>
+		<script src="../../modules/follow/js/views/post.js"></script>
 
 	</head>
 
@@ -52,5 +60,6 @@
 		<!-- Test Suites -->
 		<script src="editor.js"></script>
 		<script src="modules/time-shortcode.js"></script>
+		<script src="views/comment-boundary.js"></script>
 	</body>
 </html>

--- a/tests/qunit/views/comment-boundary.js
+++ b/tests/qunit/views/comment-boundary.js
@@ -1,0 +1,209 @@
+/* global jQuery, o2, QUnit */
+
+// Comment bodies are author-supplied HTML, so a view must not act on or read content that is not its own.
+
+function o2ClickOn( el ) {
+	return {
+		currentTarget: el,
+		target: el,
+		preventDefault: function() {},
+		stopPropagation: function() {},
+		stopImmediatePropagation: function() {}
+	};
+}
+
+// Replaces the globals these handlers reach for, and hands back a restore function.
+function o2StubGlobals() {
+	var original = {
+		options: o2.options,
+		Utilities: o2.Utilities,
+		Events: o2.Events,
+		Notifications: o2.Notifications,
+		PostActionStates: o2.PostActionStates
+	};
+
+	// postId is load-bearing: 0 sends onTrash down a different path.
+	o2.options = jQuery.extend( {}, o2.options, { postId: 7, followingBlog: false } );
+	o2.Utilities = { rawToFiltered: function( raw ) { return raw; } };
+	o2.Events = { doAction: function() {}, dispatcher: { trigger: function() {} } };
+	o2.Notifications = { add: function() {}, notifications: { findFirstAndDestroy: function() {} } };
+	o2.PostActionStates = { getNextState: function() { return 'resolved'; }, setState: function() {} };
+
+	return function() {
+		o2.options = original.options;
+		o2.Utilities = original.Utilities;
+		o2.Events = original.Events;
+		o2.Notifications = original.Notifications;
+		o2.PostActionStates = original.PostActionStates;
+	};
+}
+
+QUnit.module( 'Views.Post ownership boundary', {
+	beforeEach: function() {
+		this.restoreGlobals = o2StubGlobals();
+	},
+	afterEach: function() {
+		this.restoreGlobals();
+	}
+} );
+
+// A post view stub carrying the real guards, recording what each handler would have done.
+function o2PostUnderTest( fixture ) {
+	var did = [];
+
+	return {
+		did: did,
+		view: {
+			$el: fixture,
+			$: function( selector ) { return this.$el.find( selector ); },
+			options: { isDragging: false, viewFormat: 'standard' },
+			isPostControl: o2.Views.Post.prototype.isPostControl,
+			$post: o2.Views.Post.prototype.$post,
+			isSameHost: function() { return true; },
+			renderPost: function() {},
+			updateFollowView: function() {},
+			stickyPostView: function() {},
+			getPostModelCurrentState: function() { return 'unresolved'; },
+			setPostModelState: function() {},
+			copyToClipboard: function( text ) { did.push( text ); },
+			destroyViewModel: function() { did.push( 'trashed' ); },
+			model: {
+				save: function() { did.push( 'saved' ); },
+				changeFollow: function() {},
+				changeSticky: function() {},
+				isSticky: function() { return true; },
+				get: function() { return 7; }
+			}
+		}
+	};
+}
+
+// Each pair is a delegated post handler and the control class it answers to.
+[
+	{ handler: 'onTrash', control: 'o2-trash' },
+	{ handler: 'onShortLinkClick', control: 'o2-short-link' },
+	{ handler: 'onClickStickyPost', control: 'o2-sticky-link' },
+	{ handler: 'onClickResolvedPosts', control: 'o2-resolve-link' },
+	{ handler: 'updateFollow', control: 'o2-follow' }
+].forEach( function( subject ) {
+	QUnit.test( subject.handler + ' ignores a control planted in a comment', function( assert ) {
+		var fixture = jQuery( '#qunit-fixture' ).html(
+				'<div class="o2-post"><a class="' + subject.control + '" href="http://own.test/x">Do it</a></div>' +
+				'<div class="o2-post-comments"><div class="o2-comment">' +
+				'<a class="' + subject.control + '" id="planted" href="http://evil.test/x">Do it</a>' +
+				'</div></div>'
+			),
+			underTest = o2PostUnderTest( fixture );
+
+		o2.Views.Post.prototype[ subject.handler ].call(
+			underTest.view,
+			o2ClickOn( fixture.find( '#planted' )[ 0 ] )
+		);
+
+		assert.deepEqual( underTest.did, [], 'the planted control does nothing' );
+	} );
+} );
+
+QUnit.test( 'onTrash still trashes the post from its own control', function( assert ) {
+	var fixture = jQuery( '#qunit-fixture' ).html(
+			'<div class="o2-post"><a class="o2-trash" id="own">Trash</a></div>' +
+			'<div class="o2-post-comments"></div>'
+		),
+		underTest = o2PostUnderTest( fixture );
+
+	o2.Views.Post.prototype.onTrash.call( underTest.view, o2ClickOn( fixture.find( '#own' )[ 0 ] ) );
+
+	assert.deepEqual( underTest.did, [ 'trashed' ], 'the post\'s own control still works' );
+} );
+
+QUnit.test( 'onSave stores the post\'s own content, not a comment posing as the post', function( assert ) {
+	var sent = {},
+		fixture = jQuery( '#qunit-fixture' ).html(
+			'<div class="o2-post">' +
+			'<input class="o2-title" value="own title">' +
+			'<textarea class="o2-editor-text">own body</textarea>' +
+			'</div>' +
+			'<div class="o2-post-comments"><div class="o2-comment"><div class="o2-post">' +
+			'<input class="o2-title" value="planted title">' +
+			'<textarea class="o2-editor-text">planted body</textarea>' +
+			'</div></div></div>'
+		),
+		underTest = o2PostUnderTest( fixture );
+
+	underTest.view.model.save = function( attrs ) { sent = attrs; };
+	o2.Views.Post.prototype.onSave.call(
+		underTest.view,
+		o2ClickOn( fixture.find( '.o2-post .o2-editor-text' )[ 0 ] )
+	);
+
+	assert.strictEqual( sent.contentRaw, 'own body', 'the body comes from the post' );
+	assert.strictEqual( sent.titleRaw, 'own title', 'and so does the title' );
+} );
+
+QUnit.module( 'Views.Comment ownership boundary', {
+	beforeEach: function() {
+		this.restoreGlobals = o2StubGlobals();
+	},
+	afterEach: function() {
+		this.restoreGlobals();
+	}
+} );
+
+function o2CommentUnderTest( fixture ) {
+	var sent = {};
+
+	return {
+		sent: sent,
+		view: {
+			$el: fixture,
+			// A logged-in author, so onSave takes the branch that reads the editor.
+			options: { currentUser: { userLogin: 'author' } },
+			$ownFind: o2.Views.Comment.prototype.$ownFind,
+			model: { save: function( attrs ) { jQuery.extend( sent, attrs ); } }
+		}
+	};
+}
+
+QUnit.test( 'onSave stores the comment\'s own editor, not a reply\'s', function( assert ) {
+	var fixture = jQuery( '#qunit-fixture' ).html(
+			'<textarea class="o2-editor-text">own</textarea>' +
+			'<div class="o2-child-comments"><div class="o2-comment">' +
+			'<textarea class="o2-editor-text" style="display:none">planted</textarea>' +
+			'</div></div>'
+		),
+		underTest = o2CommentUnderTest( fixture );
+
+	o2.Views.Comment.prototype.onSave.call( underTest.view, o2ClickOn( fixture[ 0 ] ) );
+
+	assert.strictEqual( underTest.sent.contentRaw, 'own', 'the author\'s own content is what gets saved' );
+} );
+
+QUnit.test( 'onSave is not fooled by a reply nested deeper', function( assert ) {
+	var fixture = jQuery( '#qunit-fixture' ).html(
+			'<textarea class="o2-editor-text">own</textarea>' +
+			'<div class="o2-child-comments"><div class="o2-comment">' +
+			'<div class="o2-comment-text"><span>' +
+			'<textarea class="o2-editor-text">planted deeper</textarea>' +
+			'</span></div>' +
+			'</div></div>'
+		),
+		underTest = o2CommentUnderTest( fixture );
+
+	o2.Views.Comment.prototype.onSave.call( underTest.view, o2ClickOn( fixture[ 0 ] ) );
+
+	assert.strictEqual( underTest.sent.contentRaw, 'own', 'a reply nested below the top level does not win' );
+} );
+
+QUnit.test( 'a subscribe box planted in a reply does not follow the blog', function( assert ) {
+	var fixture = jQuery( '#qunit-fixture' ).html(
+			'<textarea class="o2-editor-text">own</textarea>' +
+			'<div class="o2-child-comments"><div class="o2-comment">' +
+			'<input type="checkbox" id="subscribe_blog" checked>' +
+			'</div></div>'
+		),
+		underTest = o2CommentUnderTest( fixture );
+
+	o2.Views.Comment.prototype.onSave.call( underTest.view, o2ClickOn( fixture[ 0 ] ) );
+
+	assert.false( o2.options.followingBlog, 'the planted checkbox does not follow the blog' );
+} );


### PR DESCRIPTION
Adds automated regression coverage for the post/comment ownership boundary fixed in #259, #260, #261 and #262. Tests only — no production code changes.

## The bug class

o2 renders a post and its comments inside one `<article>`, and a comment view's element contains that comment's nested replies. Backbone binds delegated handlers on the whole container, and comment bodies are author-supplied HTML. Before those fixes, a control planted inside a comment could drive the post view, and an editor planted in a reply could supply the content its parent comment saved.

Three guards hold the boundary now:

| Guard | Where | What it does |
|---|---|---|
| `isPostControl( event )` | post view | rejects an event whose `currentTarget` sits under `.o2-post-comments` |
| `$post()` | post view | scopes the post view's lookups to its own `.o2-post` |
| `$ownFind( selector )` | comment view | excludes the subtree under the comment's own `.o2-child-comments` |

## What the tests do

They drive the real handlers rather than calling the helpers directly, so a regression surfaces as a wrong value instead of a missing method. Against the pre-fix sources all nine boundary tests fail behaviorally:

```
onTrash ignores a control planted in a comment          Actual: trashed
onShortLinkClick ignores a control planted in a comment Actual: http://evil.test/x
onClickStickyPost / onClickResolvedPosts / updateFollow Actual: saved
onSave stores the post's own content                    Actual: planted body
onSave stores the comment's own editor                  Actual: planted
onSave is not fooled by a reply nested deeper           Actual: planted deeper
a subscribe box planted in a reply does not follow      Actual: true
```

Six positive-control assertions cover the other direction, so a guard that rejects everything fails too.

## Every test earns its place

Each one was checked against a targeted mutant rather than assumed useful:

- Removing the `isPostControl` guard from any one of the sticky, resolve, or follow modules is caught by exactly one test each.
- The two `onSave` lookups in the post view are asserted separately, so scoping only the title or only the body is caught.
- The nested-reply test is the only test that catches an `$ownFind` which stops excluding at the wrong depth (a `.children( '.o2-comment' ).children( selector )` mutant survives the whole suite without it).

The same method removed three things: a stub that no mutant needed, an assertion that duplicated another test's coverage, and a save/restore of a global that is never replaced or mutated.

## Harness changes

Loading the views needed `backbone` and `wp-backbone`, which the harness had commented out, plus `Models` and `Collections` on the `o2` stub because the view files read them when Backbone extends them, plus `cocktail` and the three modules that mix their handlers into the post view.

## Verification

CI runs qunit with the plugin checked out to `wp-content/plugins/o2`, which is what the harness's relative `wp-includes` paths need. Reproduced locally against that layout: 15 tests pass on trunk, 9 fail behaviorally with the pre-fix view sources swapped in.
