### PR TITLE
Draw the shortlink boundary at comment content, not at the comment list

### DIFF
--- a/js/views/post.js
+++ b/js/views/post.js
@@ -127,6 +127,14 @@ o2.Views.Post = ( function( $ ) {
 			return 0 === $( event.currentTarget ).closest( '.o2-post-comments' ).length;
 		},
 
+		// True when a delegated control sits in author-supplied comment HTML,
+		// which is everything inside `.comment-content`. Comment actions render
+		// into `.o2-comment-header`, outside it, so a handler shared by post and
+		// comment controls uses this rather than `isPostControl`.
+		isCommentContent: function( event ) {
+			return 0 < $( event.currentTarget ).closest( '.comment-content' ).length;
+		},
+
 		// keep track of whether a drag is in progress
 		onTouchStart: function() {
 			this.options.isDragging = false;
@@ -220,7 +228,7 @@ o2.Views.Post = ( function( $ ) {
 		},
 
 		onShortLinkClick: function( event ) {
-			if ( ! this.isPostControl( event ) ) {
+			if ( this.isCommentContent( event ) ) {
 				return;
 			}
 

--- a/tests/qunit/index.html
+++ b/tests/qunit/index.html
@@ -34,6 +34,12 @@
 				options: {
 					appContainer: '#qunit-fixture'
 				},
+				// Handlers that reach the notification path keep firing on a timer
+				// after a test ends, so this has to outlive any per-test stub.
+				Notifications: {
+					add: function() {},
+					notifications: { findFirstAndDestroy: function() {} }
+				},
 				// The views read these when Backbone extends them.
 				Models: {},
 				Collections: {}

--- a/tests/qunit/views/comment-boundary.js
+++ b/tests/qunit/views/comment-boundary.js
@@ -58,6 +58,7 @@ function o2PostUnderTest( fixture ) {
 			$: function( selector ) { return this.$el.find( selector ); },
 			options: { isDragging: false, viewFormat: 'standard' },
 			isPostControl: o2.Views.Post.prototype.isPostControl,
+			isCommentContent: o2.Views.Post.prototype.isCommentContent,
 			$post: o2.Views.Post.prototype.$post,
 			isSameHost: function() { return true; },
 			renderPost: function() {},
@@ -90,7 +91,9 @@ function o2PostUnderTest( fixture ) {
 		var fixture = jQuery( '#qunit-fixture' ).html(
 				'<div class="o2-post"><a class="' + subject.control + '" href="http://own.test/x">Do it</a></div>' +
 				'<div class="o2-post-comments"><div class="o2-comment">' +
+				'<div class="comment-content">' +
 				'<a class="' + subject.control + '" id="planted" href="http://evil.test/x">Do it</a>' +
+				'</div>' +
 				'</div></div>'
 			),
 			underTest = o2PostUnderTest( fixture );
@@ -102,6 +105,73 @@ function o2PostUnderTest( fixture ) {
 
 		assert.deepEqual( underTest.did, [], 'the planted control does nothing' );
 	} );
+} );
+
+// `.o2-short-link` is a post action here, but `o2_comment_actions` lets a site register the
+// same control on a comment, and o2 has no separate comment-side handler for it. So this one
+// handler answers to both, and the line it draws is author-supplied HTML rather than the
+// comment list. A wrapper class cannot be used instead: comment content is filtered with
+// `wp_filter_post_kses` wherever a site allows post HTML in comments, which permits `div` and
+// the global `class` attribute, so an author could wrap a planted control to match. Ancestry
+// is not forgeable in the same way.
+QUnit.test( 'onShortLinkClick copies from a control rendered as a comment action', function( assert ) {
+	var fixture = jQuery( '#qunit-fixture' ).html(
+			'<div class="o2-post"></div>' +
+			'<div class="o2-post-comments"><div class="o2-comment">' +
+			'<div class="o2-comment-header"><nav class="o2-comment-actions">' +
+			'<a class="o2-short-link" id="own" href="http://own.test/?p=1#comment-9">Copy shortlink</a>' +
+			'</nav></div>' +
+			'<div class="comment-content">A comment body.</div>' +
+			'</div></div>'
+		),
+		underTest = o2PostUnderTest( fixture );
+
+	o2.Views.Post.prototype.onShortLinkClick.call(
+		underTest.view,
+		o2ClickOn( fixture.find( '#own' )[ 0 ] )
+	);
+
+	assert.deepEqual(
+		underTest.did,
+		[ 'http://own.test/?p=1#comment-9' ],
+		'a comment action outside .comment-content still copies'
+	);
+} );
+
+QUnit.test( 'onShortLinkClick ignores a control wrapped to look like a comment action', function( assert ) {
+	var fixture = jQuery( '#qunit-fixture' ).html(
+			'<div class="o2-post"></div>' +
+			'<div class="o2-post-comments"><div class="o2-comment">' +
+			'<div class="comment-content"><nav class="o2-comment-actions">' +
+			'<a class="o2-short-link" id="planted" href="http://evil.test/x">Copy shortlink</a>' +
+			'</nav></div>' +
+			'</div></div>'
+		),
+		underTest = o2PostUnderTest( fixture );
+
+	o2.Views.Post.prototype.onShortLinkClick.call(
+		underTest.view,
+		o2ClickOn( fixture.find( '#planted' )[ 0 ] )
+	);
+
+	assert.deepEqual( underTest.did, [], 'the wrapper class does not buy its way out of .comment-content' );
+} );
+
+QUnit.test( 'onShortLinkClick still copies the post\'s own shortlink', function( assert ) {
+	var fixture = jQuery( '#qunit-fixture' ).html(
+			'<div class="o2-post">' +
+			'<a class="o2-short-link" id="own" href="http://own.test/?p=1">Copy shortlink</a>' +
+			'</div>' +
+			'<div class="o2-post-comments"></div>'
+		),
+		underTest = o2PostUnderTest( fixture );
+
+	o2.Views.Post.prototype.onShortLinkClick.call(
+		underTest.view,
+		o2ClickOn( fixture.find( '#own' )[ 0 ] )
+	);
+
+	assert.deepEqual( underTest.did, [ 'http://own.test/?p=1' ], 'the post\'s own control still works' );
 } );
 
 QUnit.test( 'onTrash still trashes the post from its own control', function( assert ) {


### PR DESCRIPTION
Follow-up to #261. That PR scoped four delegated handlers to the post; three of them were right, and `onShortLinkClick` was not.

## What is wrong

`isPostControl()` rejects any control inside `.o2-post-comments`. For `updateFollow`, `onClickStickyPost` and `onClickResolvedPosts` that is exactly right — they act on the post model, so a control outside the post has no business reaching them.

`onShortLinkClick` is different. It is the only handler bound to `.o2-short-link`, and `o2_comment_actions` lets a site register that same control on a comment, where copying the comment's own link is the entire point. There is no comment-side handler to fall back on, so the guard left every such control dead.

## The boundary this handler needs

Author-supplied HTML, not the comment list. Comment actions render into `.o2-comment-header` through `commentDropdownActions`; comment bodies render into `.comment-content` (`inc/tpl/comment.php`). So `isCommentContent()` rejects `.comment-content` and nothing else.

Kept as a negative check deliberately. A container allowlist — "allow it if it is inside `.o2-comment-actions`" — reads tighter but is weaker: a site that allows post HTML in comments filters them with `wp_filter_post_kses`, which permits `div` and the global `class` attribute, so a comment author could wrap a planted control to match. `closest()` walks real ancestors, which a comment body cannot escape. There is a test for exactly that.

`isPostControl()` and its other four callers are unchanged.

## Test coverage

The fixture from #263 planted its control directly in `.o2-comment`, which no real comment renders — it now wraps it in `.comment-content` so it matches the template. Three cases added around the shortlink handler:

| Case | Expected |
|---|---|
| Control rendered as a comment action, in `.o2-comment-header` | copies |
| The post's own `.o2-short-link` | copies |
| Control planted in `.comment-content`, wrapped in `.o2-comment-actions` | ignored |

Verified by running them against both broken states rather than by reading them:

- Reinstate `isPostControl()` on this handler → "copies from a control rendered as a comment action" fails.
- Drop the guard entirely → the two "ignores" cases fail.

18 tests, 24 assertions, all passing on this branch. `grunt lint` clean.

## Harness change

`tests/qunit/index.html` gains a lasting `o2.Notifications` stub. The handler's success path schedules a notification cleanup 2.5s later; until now no test drove that path, so the timer never fired after the per-test stub was restored. It does now, and without this it throws once the suite has already finished.
