### PR TITLE
Let the QUnit suite run from a plain checkout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,16 +46,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-        with:
-          path: wp-content/plugins/o2
-      - name: Unpack WordPress core for the jQuery and Underscore the test page loads
-        run: curl -sL https://wordpress.org/latest.tar.gz | tar -xz --strip-components=1
       - uses: actions/setup-node@v4
         with:
           node-version: 22
           cache: npm
-          cache-dependency-path: wp-content/plugins/o2/package-lock.json
       - run: npm ci
-        working-directory: wp-content/plugins/o2
+      # Fetches the WordPress core scripts the test page loads. Kept as its own
+      # step so a WordPress.org outage reads as itself, not as a test failure.
+      - run: bin/install-qunit-deps.sh
       - run: npx grunt qunit
-        working-directory: wp-content/plugins/o2

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -82,7 +82,7 @@ module.exports = function(grunt) {
 					args: ['-c', 'phpunit.xml.dist']
 				}
 			},
-			qunit: {
+			'contrib-qunit': {
 				all: [ 'tests/qunit/index.html' ]
 			}
 		};
@@ -91,6 +91,7 @@ module.exports = function(grunt) {
 
 	grunt.loadNpmTasks('grunt-contrib-jshint');
 	grunt.loadNpmTasks('grunt-contrib-qunit');
+	grunt.renameTask( 'qunit', 'contrib-qunit' );
 	grunt.loadNpmTasks('grunt-sass');
 	grunt.loadNpmTasks('grunt-wp-i18n');
 	grunt.loadNpmTasks('grunt-rtlcss');
@@ -137,6 +138,28 @@ module.exports = function(grunt) {
 			opts: {stdio: 'inherit'}
 		}, this.async());
 	});
+
+	grunt.registerTask( 'qunit-deps', 'Fetches the WordPress core scripts the QUnit page loads.', function() {
+		if ( grunt.file.exists( 'tests/qunit/vendor/.wp-version' ) ) {
+			return;
+		}
+
+		var done = this.async();
+
+		grunt.log.writeln( 'tests/qunit/vendor is empty, fetching WordPress core scripts.' );
+
+		grunt.util.spawn( {
+			cmd: 'bin/install-qunit-deps.sh',
+			opts: { stdio: 'inherit' }
+		}, function( error ) {
+			if ( error ) {
+				grunt.log.error( 'Could not fetch them. Run bin/install-qunit-deps.sh by hand to see why.' );
+			}
+			done( ! error );
+		} );
+	} );
+
+	grunt.registerTask( 'qunit', 'Runs the QUnit suite.', [ 'qunit-deps', 'contrib-qunit' ] );
 
 	grunt.registerTask( 'lint', 'Runs PHP and JavaScript lint checks.', [ 'phplint', 'jshint' ] );
 };

--- a/HACKING.txt
+++ b/HACKING.txt
@@ -58,5 +58,6 @@ There are a number of core modules provided, which will give you an idea on how 
 * Run 'composer install' to get PHPUnit and the polyfills the WordPress test library needs
 * Run 'bash bin/install-wp-tests.sh <db-name> <db-user> <db-pass> [db-host] [wp-version]' once to install WordPress and its test library into /tmp (needs git and a MySQL server)
 * Run 'vendor/bin/phpunit' (or 'grunt phpunit') for the PHP tests
-* Run 'grunt qunit' for the JavaScript tests. The test page loads jQuery and Underscore from WordPress core, so the plugin has to sit at wp-content/plugins/o2 inside a WordPress install
+* Run 'grunt qunit' for the JavaScript tests. It works from a plain checkout anywhere on disk
+* The QUnit page runs against the jQuery, Underscore and Backbone that WordPress ships rather than npm builds of them, so a failure means something about o2 and not about a version WordPress never serves. 'grunt qunit' fetches them into tests/qunit/vendor on first run; 'bash bin/install-qunit-deps.sh [wp-version]' does it by hand, and takes a version to test against an older WordPress
 * 'npm test' runs lint, PHPUnit, and QUnit together

--- a/bin/install-qunit-deps.sh
+++ b/bin/install-qunit-deps.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+#
+# Fetches the WordPress core scripts the QUnit page loads.
+#
+# The suite runs against the same jQuery, Underscore, Backbone and wp.Backbone
+# that WordPress ships, rather than npm builds of them, so that a failure means
+# something about o2 and not about a version WordPress never serves.
+#
+# usage: bin/install-qunit-deps.sh [wp-version]
+
+set -e
+
+WP_VERSION=${1-latest}
+VENDOR_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )/tests/qunit/vendor"
+
+FILES=(
+	"wp-includes/js/jquery/jquery.js"
+	"wp-includes/js/underscore.min.js"
+	"wp-includes/js/backbone.min.js"
+	"wp-includes/js/wp-backbone.js"
+)
+
+download() {
+	if [ "$( which curl )" ]; then
+		curl -f -s "$1" > "$2"
+	elif [ "$( which wget )" ]; then
+		wget -nv -O "$2" "$1"
+	else
+		echo "Neither curl nor wget is available." >&2
+		exit 1
+	fi
+}
+
+# Writes through a temporary file so a failed fetch cannot leave a truncated
+# one behind for the version stamp to later declare good.
+download_atomic() {
+	local tmp="$2.part"
+	download "$1" "$tmp"
+	mv "$tmp" "$2"
+}
+
+resolve_version() {
+	if [[ $WP_VERSION == 'trunk' || $WP_VERSION == 'nightly' ]]; then
+		echo 'trunk'
+		return
+	fi
+
+	if [[ $WP_VERSION =~ ^[0-9]+\.[0-9]+(\.[0-9]+)?$ ]]; then
+		echo "tags/$WP_VERSION"
+		return
+	fi
+
+	# http serves a single offer, whereas https serves multiple. We only want one.
+	local latest
+	latest=$( download http://api.wordpress.org/core/version-check/1.7/ /dev/stdout \
+		| grep -o '"version":"[^"]*' | head -1 | sed 's/"version":"//' )
+
+	if [ -z "$latest" ]; then
+		echo "Latest WordPress version could not be found." >&2
+		exit 1
+	fi
+
+	echo "tags/$latest"
+}
+
+TAG=$( resolve_version )
+STAMP="$VENDOR_DIR/.wp-version"
+
+if [ -f "$STAMP" ] && [ "$( cat "$STAMP" )" = "$TAG" ]; then
+	echo "QUnit dependencies already at $TAG."
+	exit 0
+fi
+
+mkdir -p "$VENDOR_DIR"
+
+trap 'rm -f "$VENDOR_DIR"/*.part' EXIT
+
+# The stamp goes last, so an interrupted run re-fetches rather than passing off
+# a half-populated directory as complete.
+rm -f "$STAMP"
+
+for file in "${FILES[@]}"; do
+	echo "Fetching $file from $TAG"
+	download_atomic "https://core.svn.wordpress.org/$TAG/$file" "$VENDOR_DIR/$( basename "$file" )"
+done
+
+echo "$TAG" > "$STAMP"
+echo "QUnit dependencies installed from $TAG into tests/qunit/vendor."

--- a/tests/qunit/index.html
+++ b/tests/qunit/index.html
@@ -6,17 +6,11 @@
 		<title>o2 QUnit Test Suite</title>
 		<link rel="stylesheet" href="https://code.jquery.com/qunit/qunit-2.26.0.css">
 
-		<!-- General Dependencies -->
-		<script src="../../../../../wp-includes/js/jquery/jquery.js"></script>
-		<script src="../../../../../wp-includes/js/underscore.min.js"></script>
-		<script src="../../../../../wp-includes/js/backbone.min.js"></script>
-		<script src="../../../../../wp-includes/js/wp-backbone.js"></script>
-
-		<!-- 
-		These other ones aren't needed yet, but may be down the line
-		<script src="../../../../../wp-includes/js/jquery/ui/core.js"></script>
-		<script src="../../../../../wp-includes/js/wp-util.js"></script>
-		-->
+		<!-- General Dependencies. Run bin/install-qunit-deps.sh to populate vendor/. -->
+		<script src="vendor/jquery.js"></script>
+		<script src="vendor/underscore.min.js"></script>
+		<script src="vendor/backbone.min.js"></script>
+		<script src="vendor/wp-backbone.js"></script>
 
 		<!-- Plugin Dependencies -->
 		<script>


### PR DESCRIPTION
`npx grunt qunit` did not work from a normal clone. Now it does, with no setup beyond `npm ci`.

## What was wrong

`tests/qunit/index.html` loaded jQuery, Underscore, Backbone and `wp.Backbone` through `../../../../../wp-includes/`. That path only resolves when the plugin sits at `wp-content/plugins/o2` inside a WordPress install, which a clone does not. In a plain checkout the suite died with eleven failures, all downstream of `jQuery is not defined` — a wall of assertion errors that says nothing about the actual problem:

```
>> ReferenceError: jQuery is not defined
>> Message: afterEach failed on ...: this.restoreGlobals is not a function
Warning: 15 tests completed in 8ms, with 11 failed
```

CI papered over it by checking the repo out into `wp-content/plugins/o2` and unpacking a full WordPress tarball over the workspace, which is why nobody noticed.

## What changed

`bin/install-qunit-deps.sh` fetches those four files into `tests/qunit/vendor` (already gitignored by the existing `vendor` rule), and the page loads them by a relative path that holds wherever the checkout lives. The `qunit` task runs the script when the directory is missing, so the first run just works.

Still WordPress core's own copies rather than npm builds of the same libraries. The value of this suite is that o2 works against what WordPress actually serves; an npm jQuery would quietly be testing something else. Files come from `core.svn.wordpress.org`, matching how `bin/install-wp-tests.sh` already sources WordPress, and the version resolves through the same `api.wordpress.org` version-check call. The script takes a version, so `bin/install-qunit-deps.sh 6.9` runs the suite against an older release.

Downloads land through a temporary file and the version stamp is written last, so an interrupted or failed run re-fetches rather than leaving a truncated file that the stamp would later declare good. Found that by pointing it at a version that does not exist, which left a zero-byte `jquery.js` next to a stamp claiming everything was fine.

CI loses the checkout path and the tarball and becomes the same shape as the `lint` job. The fetch is its own step so a WordPress.org outage reads as itself rather than as a test failure.

`HACKING.txt` had documented the old constraint; it now describes the actual workflow.

## Verification

From a genuine `git clone` of this branch into a fresh directory, nothing else present:

| Step | Result |
|---|---|
| `npm ci && npx grunt qunit` | fetches deps, 15 tests pass |
| second `npx grunt qunit` | skips the fetch, 15 tests pass |
| `npx grunt lint` | 80 files lint free |
| `bin/install-qunit-deps.sh 6.9 && npx grunt qunit` | 15 tests pass against WordPress 6.9 |
| `bin/install-qunit-deps.sh 99.99` | exits 56, leaves no files and no stamp |

## Note on #264

#264 also touches `tests/qunit/index.html`, in the `window.o2` block rather than the script tags. The two are independent and either order works; whichever lands second may want a rebase.
